### PR TITLE
Update GitHub Actions to current Node.js release lines

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -10,7 +10,7 @@ jobs:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
     strategy:
       matrix:
-        node: [20, 22]
+        node: [24, 25]
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
- update the CI Node.js matrix from 20/22 to 24/25
- keep GitHub Actions aligned with the active LTS and current Node.js release lines
- limit the change to the workflow matrix only

## Testing
- pnpm prettier --check .github/workflows/nodejs.yml

Closes #2565