### PR TITLE
chore: bump GitHub Actions Node versions

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -10,7 +10,7 @@ jobs:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
     strategy:
       matrix:
-        node: [20, 22]
+        node: [24, 25]
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
- update the CI Node.js matrix from 20/22 to 24/25
- keep GitHub Actions aligned with the active and current Node.js release lines

Closes #2565

## Testing
- not run (GitHub Actions workflow-only change)