### PR TITLE
Fix grouped tab bottom indicator length

### DIFF
--- a/packages/extension/src/js/components/Tab/Tab.tsx
+++ b/packages/extension/src/js/components/Tab/Tab.tsx
@@ -137,6 +137,7 @@ export default observer((props: TabProps & { className?: string }) => {
       <TabTools tab={tab} />
       <CloseButton onClick={onRemove} disabled={tab.removing} />
       <ContainerOrGroupIndicator
+        id={tab.id}
         groupId={tab.groupId}
         cookieStoreId={tab.cookieStoreId}
       />

--- a/packages/extension/src/js/components/Tab/_TabGroupIndicator.tsx
+++ b/packages/extension/src/js/components/Tab/_TabGroupIndicator.tsx
@@ -4,8 +4,10 @@ import Tab from 'stores/Tab'
 import { TabGroup } from 'stores/TabGroupStore'
 import { getChromeTabGroupColor } from 'libs/chromeTabGroupColors'
 
+const GROUP_INDICATOR_INSET = 6
+
 const _TabGroupIndicator = (props: Tab) => {
-  const { groupId } = props
+  const { groupId, id } = props
   const { tabGroupStore } = useStore()
   if (!tabGroupStore) {
     return null
@@ -18,9 +20,10 @@ const _TabGroupIndicator = (props: Tab) => {
   return (
     <hr
       className="absolute border-0"
+      data-testid={`tab-group-indicator-${id}`}
       style={{
-        left: 12,
-        right: 12,
+        left: GROUP_INDICATOR_INSET,
+        right: GROUP_INDICATOR_INSET,
         bottom: 0,
         margin: 0,
         borderTopColor: color,

--- a/packages/extension/src/js/components/Tab/__tests__/_TabGroupIndicator.test.tsx
+++ b/packages/extension/src/js/components/Tab/__tests__/_TabGroupIndicator.test.tsx
@@ -4,6 +4,7 @@ import TabGroupIndicator from '../_TabGroupIndicator'
 import { render } from '@testing-library/react'
 
 const VALID_GROUP_ID = 42
+const VALID_TAB_ID = 7
 
 const mockStore = {
   tabGroupStore: {
@@ -24,7 +25,9 @@ describe('TabGroupIndicator', () => {
 
   it('render valid content if groupId is valid', () => {
     const { container } = render(
-      <TabGroupIndicator {...({ groupId: VALID_GROUP_ID } as any)} />,
+      <TabGroupIndicator
+        {...({ id: VALID_TAB_ID, groupId: VALID_GROUP_ID } as any)}
+      />,
     )
     expect(container).toMatchSnapshot()
   })

--- a/packages/extension/src/js/components/Tab/__tests__/__snapshots__/_TabGroupIndicator.test.tsx.snap
+++ b/packages/extension/src/js/components/Tab/__tests__/__snapshots__/_TabGroupIndicator.test.tsx.snap
@@ -6,7 +6,8 @@ exports[`TabGroupIndicator render valid content if groupId is valid 1`] = `
 <div>
   <hr
     class="absolute border-0"
-    style="left: 12px; right: 12px; bottom: 0px; margin: 0px; border-top-color: #1a73e8; border-top-width: 1px; border-top-style: solid;"
+    data-testid="tab-group-indicator-7"
+    style="left: 6px; right: 6px; bottom: 0px; margin: 0px; border-top-color: #1a73e8; border-top-width: 1px; border-top-style: solid;"
   />
 </div>
 `;

--- a/packages/integration_test/test/views.test.ts
+++ b/packages/integration_test/test/views.test.ts
@@ -208,6 +208,14 @@ test.describe('The Extension page should', () => {
     expect(groupedTabIds).toHaveLength(2)
     for (const tabId of groupedTabIds) {
       await expect(page.getByTestId(`tab-row-${tabId}`)).toHaveCount(1)
+      await expect(page.getByTestId(`tab-group-indicator-${tabId}`)).toHaveCSS(
+        'left',
+        '6px',
+      )
+      await expect(page.getByTestId(`tab-group-indicator-${tabId}`)).toHaveCSS(
+        'right',
+        '6px',
+      )
     }
 
     await page.getByTestId(`tab-group-toggle-${groupId}`).click()


### PR DESCRIPTION
## Summary
- reduce the grouped tab row indicator inset so the bottom line reads longer
- pass the tab id through the row indicator path so grouped indicators can be targeted reliably
- add integration coverage for the grouped indicator left/right offsets

## Testing
- pnpm --filter tab-manager-v2 exec jest --maxWorkers=1 --watchman=false packages/extension/src/js/components/Tab/__tests__/_TabGroupIndicator.test.tsx packages/extension/src/js/components/Tab/__tests__/ContainerOrGroupIndicator.test.tsx
- pnpm --filter tab-manager-v2 build:chrome
- pnpm --filter integration-test test -- --grep "render grouped headers and support collapse/rename/color updates"

## Notes
- Fixes #2568
- Snapshot-sensitive popup UI change; Ubuntu/Linux visual CI is still pending.