### PR TITLE
Make search results show matching group titles

### DIFF
--- a/packages/extension/src/js/components/AutocompleteSearch/TabOption.tsx
+++ b/packages/extension/src/js/components/AutocompleteSearch/TabOption.tsx
@@ -1,0 +1,119 @@
+import React, { SyntheticEvent, useCallback } from 'react'
+import { observer } from 'mobx-react-lite'
+import classNames from 'classnames'
+import { useTheme } from '@mui/material/styles'
+import CloseButton from 'components/CloseButton'
+import HighlightNode from 'components/HighlightNode'
+import RowActionSlot from 'components/RowActionSlot'
+import RowActionRail from 'components/RowActionRail'
+import ContainerOrGroupIndicator from 'components/Tab/ContainerOrGroupIndicator'
+import DuplicateMarker from 'components/Tab/DuplicateMarker'
+import Icon from 'components/Tab/Icon'
+import PIN from 'components/Tab/Pin'
+import TabTools from 'components/Tab/TabTools'
+import { useStore } from 'components/hooks/useStore'
+import { MIN_INTERACTIVE_ROW_HEIGHT } from 'libs/layoutMetrics'
+import { matchesSearchText } from 'stores/SearchStore'
+import Tab from 'stores/Tab'
+
+type Props = {
+  tab: Tab
+}
+
+export default observer(function TabOption(props: Props) {
+  const { tab } = props
+  const { searchStore, userStore } = useStore()
+  const { query } = searchStore
+  const theme = useTheme()
+  const showGroupTitle = matchesSearchText(tab.groupTitle, query)
+  const pin = tab.pinned && PIN
+
+  const onRemove = (event: React.SyntheticEvent) => {
+    event.stopPropagation()
+    const { removing, remove } = tab
+    if (!removing) {
+      remove()
+    }
+  }
+
+  const onAuxClick = (event: SyntheticEvent) => {
+    if (event.button === 1 && !tab.removing) {
+      tab.remove()
+    }
+  }
+
+  const getHighlightNode = useCallback(
+    (text) => {
+      if (!query) {
+        return text
+      }
+      return <HighlightNode {...{ query, text }} />
+    },
+    [query],
+  )
+
+  return (
+    <div tabIndex={-1} className="relative flex w-full">
+      {pin}
+      <Icon tab={tab} faked />
+      <button
+        className="group m-0 flex h-12 flex-1 flex-col justify-center overflow-hidden rounded-sm text-left text-base"
+        style={{ minHeight: MIN_INTERACTIVE_ROW_HEIGHT }}
+        onAuxClick={onAuxClick}
+      >
+        <div className="w-full min-w-0 overflow-hidden truncate">
+          {getHighlightNode(tab.title)}
+        </div>
+        {(userStore.showUrl || showGroupTitle) && (
+          <div
+            className={classNames(
+              'flex w-full items-center gap-1 overflow-hidden text-xs opacity-75 transition-colors group-hover:opacity-100',
+              {
+                'group-hover:text-gray-900': theme.palette.mode !== 'dark',
+                'group-hover:text-gray-100': theme.palette.mode === 'dark',
+              },
+            )}
+            style={{
+              color: theme.palette.mode === 'dark' ? '#aeb5c0' : '#64748b',
+            }}
+          >
+            {userStore.showUrl && (
+              <div
+                className={classNames('min-w-0 overflow-hidden truncate', {
+                  'flex-1': showGroupTitle,
+                  'w-full': !showGroupTitle,
+                })}
+              >
+                {getHighlightNode(tab.url)}
+              </div>
+            )}
+            {showGroupTitle && (
+              <div
+                className={classNames('min-w-0 overflow-hidden truncate', {
+                  'max-w-[45%] shrink-0': userStore.showUrl,
+                  'w-full': !userStore.showUrl,
+                })}
+              >
+                in {tab.groupTitle}
+              </div>
+            )}
+          </div>
+        )}
+      </button>
+      <RowActionRail tail={<DuplicateMarker tab={tab} faked />}>
+        <TabTools tab={tab} faked />
+        <RowActionSlot>
+          <CloseButton
+            onClick={onRemove}
+            disabled={tab.removing}
+            size="compact"
+          />
+        </RowActionSlot>
+      </RowActionRail>
+      <ContainerOrGroupIndicator
+        groupId={tab.groupId}
+        cookieStoreId={tab.cookieStoreId}
+      />
+    </div>
+  )
+})

--- a/packages/extension/src/js/components/AutocompleteSearch/index.tsx
+++ b/packages/extension/src/js/components/AutocompleteSearch/index.tsx
@@ -3,18 +3,18 @@ import { observer } from 'mobx-react-lite'
 import { TextField, Paper } from '@mui/material'
 import Autocomplete from '@mui/material/Autocomplete'
 import { useTheme } from '@mui/material/styles'
-import ViewOnlyTab from 'components/Tab/ViewOnlyTab'
 import { useStore } from 'components/hooks/useStore'
 import { useSearchInputRef } from 'components/hooks/useSearchInputRef'
 import { useOptions } from 'components/hooks/useOptions'
 import ListboxComponent from './ListboxComponent'
+import TabOption from './TabOption'
 import { matchSorter, defaultBaseSortFn } from 'match-sorter'
 import parse from 'autosuggest-highlight/parse'
 import match from 'autosuggest-highlight/match'
 import Shortcuts from 'components/Shortcut/Shortcuts'
 import HistoryItemTab from 'components/Tab/HistoryItemTab'
 import Tab from 'stores/Tab'
-import { HistoryItem } from 'stores/SearchStore'
+import { HistoryItem, getTabSearchKeys } from 'stores/SearchStore'
 import { openURL } from 'libs'
 
 const SEARCH_PLACEHOLDER = 'Search tabs or URLs'
@@ -52,15 +52,15 @@ function sortRankedValues(a, b, baseSort): number {
   }
 }
 
-const getFilterOptions = (showUrl, isCommand) => {
+const getFilterOptions = (showUrl, isCommand, hasTabGroupsApi) => {
   if (isCommand) {
     return commandFilter
   }
   return (options, { inputValue }) => {
-    const keys = ['title']
-    if (showUrl) {
-      keys.push('url')
-    }
+    const keys = getTabSearchKeys({
+      showUrl,
+      hasTabGroupsApi,
+    })
     return matchSorter(options, inputValue, {
       keys,
       sorter: (rankedItems) => {
@@ -84,9 +84,9 @@ const getFilterOptions = (showUrl, isCommand) => {
   }
 }
 
-type TabOption = HistoryItem | Tab | { isDivider: boolean; title: string }
+type SearchOption = HistoryItem | Tab | { isDivider: boolean; title: string }
 
-const renderTabOption = (tab: TabOption) => {
+const renderTabOption = (tab: SearchOption) => {
   if (tab.isDivider) {
     return (
       <div className="flex items-center justify-between w-full h-full pl-2 font-bold border-t-2">
@@ -101,7 +101,7 @@ const renderTabOption = (tab: TabOption) => {
   if (tab.visitCount) {
     return <HistoryItemTab tab={tab} />
   }
-  return <ViewOnlyTab tab={tab} />
+  return <TabOption tab={tab} />
 }
 
 const renderCommand = (command, state) => {
@@ -134,9 +134,13 @@ const AutocompleteSearch = observer((props: Props) => {
   const theme = useTheme()
   const searchInputRef = useSearchInputRef()
   const options = useOptions()
-  const { userStore, searchStore } = useStore()
+  const { userStore, searchStore, tabGroupStore } = useStore()
   const { search, query, startType, stopType, isCommand } = searchStore
-  const filterOptions = getFilterOptions(userStore.showUrl, isCommand)
+  const filterOptions = getFilterOptions(
+    userStore.showUrl,
+    isCommand,
+    !!tabGroupStore?.hasTabGroupsApi?.(),
+  )
 
   return (
     <Autocomplete
@@ -224,7 +228,14 @@ const AutocompleteSearch = observer((props: Props) => {
       )}
       options={options}
       getOptionLabel={(option) =>
-        `${option.name} ${option.title} ${option.url}`
+        [
+          option.name,
+          option.title,
+          option.url,
+          option.visitCount ? '' : option.groupTitle,
+        ]
+          .filter(Boolean)
+          .join(' ')
       }
       getOptionDisabled={(option) => option.isDivider}
       renderOption={(props, option, state) => (

--- a/packages/extension/src/js/stores/SearchStore.tsx
+++ b/packages/extension/src/js/stores/SearchStore.tsx
@@ -11,6 +11,32 @@ const hasCommandPrefix = (value: string) => value.startsWith('>')
 
 const DAY_IN_MILLISECONDS = 1000 * 60 * 60 * 24
 
+export const matchesSearchText = (text: string, query: string) => {
+  const normalizedText = (text || '').trim()
+  const normalizedQuery = (query || '').trim()
+  if (!normalizedText || !normalizedQuery) {
+    return false
+  }
+  return matchSorter([normalizedText], normalizedQuery).length > 0
+}
+
+export const getTabSearchKeys = ({
+  showUrl,
+  hasTabGroupsApi,
+}: {
+  showUrl: boolean
+  hasTabGroupsApi: boolean
+}) => {
+  const keys = ['title']
+  if (showUrl) {
+    keys.push('url')
+  }
+  if (hasTabGroupsApi) {
+    keys.push('groupTitle')
+  }
+  return keys
+}
+
 export type HistoryItem = {
   id: string
   lastVisitTime?: number
@@ -170,13 +196,10 @@ export default class SearchStore {
     if (!this._query) {
       return tabs
     }
-    const keys = ['title']
-    if (this.store.userStore.showUrl) {
-      keys.push('url')
-    }
-    if (this.store.tabGroupStore?.hasTabGroupsApi?.()) {
-      keys.push('groupTitle')
-    }
+    const keys = getTabSearchKeys({
+      showUrl: this.store.userStore.showUrl,
+      hasTabGroupsApi: !!this.store.tabGroupStore?.hasTabGroupsApi?.(),
+    })
     return matchSorter(tabs, this._query, { keys })
   }
 

--- a/packages/extension/src/js/stores/__tests__/SearchStore.test.tsx
+++ b/packages/extension/src/js/stores/__tests__/SearchStore.test.tsx
@@ -1,4 +1,4 @@
-import SearchStore from 'stores/SearchStore'
+import SearchStore, { matchesSearchText } from 'stores/SearchStore'
 
 describe('SearchStore', () => {
   it('should repack layout after updating the active search query', async () => {
@@ -71,5 +71,12 @@ describe('SearchStore', () => {
 
     expect(searchStore.matchedTabs.map((tab) => tab.id)).toEqual([2])
     expect(Array.from(searchStore.matchedSet)).toEqual([1, 2])
+  })
+
+  it('should detect when a query matches a group title', () => {
+    expect(matchesSearchText('SearchDocs', 'SearchDocs')).toBe(true)
+    expect(matchesSearchText('SearchDocs', 'docs')).toBe(true)
+    expect(matchesSearchText('SearchDocs', 'nextjs')).toBe(false)
+    expect(matchesSearchText('', 'docs')).toBe(false)
   })
 })

--- a/packages/integration_test/test/views.behavior.test.ts
+++ b/packages/integration_test/test/views.behavior.test.ts
@@ -479,6 +479,56 @@ test.describe('The Extension page should', () => {
     }
   })
 
+  test('show group title metadata only when the search query matches the group title', async () => {
+    await page.evaluate(async () => {
+      await chrome.storage.local.set({
+        query: '',
+        showUnmatchedTab: true,
+      })
+    })
+    await page.reload()
+    await page.waitForTimeout(700)
+
+    const alphaUrl =
+      'data:text/html,<title>Alpha%20Guide</title>alpha-group-search'
+    const betaUrl =
+      'data:text/html,<title>Beta%20Guide</title>beta-group-search'
+    await openPages(browserContext, [alphaUrl, betaUrl])
+    await page.bringToFront()
+    await page.waitForTimeout(800)
+
+    const groupId = await groupTabsByUrl(page, {
+      urls: [alphaUrl, betaUrl],
+      title: 'SearchDocs',
+      color: 'blue',
+    })
+    expect(groupId).toBeGreaterThan(-1)
+    await page.waitForTimeout(800)
+    await page.reload()
+    await waitForTestId(page, `tab-group-header-${groupId}`)
+
+    const searchInput = page.locator(
+      'input[placeholder*="Search tabs or URLs"]',
+    )
+    await expect(searchInput).toBeVisible()
+
+    await searchInput.fill('SearchDocs')
+    await page.waitForTimeout(700)
+    const groupMatchedOption = page
+      .locator('.MuiAutocomplete-option')
+      .filter({ hasText: 'Alpha Guide' })
+      .first()
+    await expect(groupMatchedOption).toContainText('in SearchDocs')
+
+    await searchInput.fill('Alpha Guide')
+    await page.waitForTimeout(700)
+    const titleMatchedOption = page
+      .locator('.MuiAutocomplete-option')
+      .filter({ hasText: 'Alpha Guide' })
+      .first()
+    await expect(titleMatchedOption).not.toContainText('in SearchDocs')
+  })
+
   test('remove one tab from a group without breaking remaining grouped tabs', async () => {
     await page.evaluate(async () => {
       await chrome.storage.local.set({


### PR DESCRIPTION
## Summary
- make autocomplete search index tab group titles alongside tab titles and URLs
- show a muted `in <group>` label only when the current query matched the group title
- add unit and Playwright coverage for the conditional group-title metadata

## Testing
- `pnpm build`
- `pnpm --filter tab-manager-v2 test -- SearchStore.test.tsx`
- `pnpm --filter integration-test test -- --grep "group title"`

## Notes
- Popup/autocomplete UI is snapshot-sensitive.
- Linux visual snapshot verification is still pending in CI.