### PR TITLE
Fix command search for reordered terms

### DIFF
--- a/packages/extension/src/js/components/AutocompleteSearch/__tests__/filterOptions.test.ts
+++ b/packages/extension/src/js/components/AutocompleteSearch/__tests__/filterOptions.test.ts
@@ -1,0 +1,45 @@
+import {
+  filterCommandOptions,
+  type CommandOption,
+} from 'components/AutocompleteSearch/filterOptions'
+
+describe('filterCommandOptions', () => {
+  it('should match the same commands regardless of word order', () => {
+    const options: CommandOption[] = [
+      {
+        name: 'Collapse all windows',
+        shortcut: 'w c',
+      },
+      {
+        name: 'Expand all windows',
+        shortcut: 'w e',
+      },
+      {
+        name: 'Open this window in new tab',
+        shortcut: 'ctrl+o',
+      },
+      {
+        name: 'Toggle collapse/expand for all windows',
+        shortcut: 'w t',
+      },
+      {
+        name: 'Toggle collapse/expand for current windows',
+        shortcut: 'w w',
+      },
+    ]
+
+    const expected = filterCommandOptions(options, 'expand window').map(
+      ({ name }) => name,
+    )
+    const actual = filterCommandOptions(options, 'window expand').map(
+      ({ name }) => name,
+    )
+
+    expect(actual).toEqual(expected)
+    expect(actual).toEqual([
+      'Expand all windows',
+      'Toggle collapse/expand for all windows',
+      'Toggle collapse/expand for current windows',
+    ])
+  })
+})

--- a/packages/extension/src/js/components/AutocompleteSearch/filterOptions.ts
+++ b/packages/extension/src/js/components/AutocompleteSearch/filterOptions.ts
@@ -1,0 +1,41 @@
+import { matchSorter } from 'match-sorter'
+
+export type CommandOption = {
+  name: string
+  shortcut?: string | string[]
+}
+
+const COMMAND_KEYS = ['name', 'shortcut']
+
+const getCommandQueryTerms = (query: string) =>
+  query.trim().split(/\s+/).filter(Boolean)
+
+const getCommandRankMaps = (options: CommandOption[], terms: string[]) =>
+  terms.map((term) => {
+    const matches = matchSorter(options, term, {
+      keys: COMMAND_KEYS,
+    })
+    return new Map(matches.map((option, index) => [option, index]))
+  })
+
+export const filterCommandOptions = (
+  options: CommandOption[],
+  query: string,
+) => {
+  const terms = getCommandQueryTerms(query)
+  if (!terms.length) {
+    return options
+  }
+
+  const rankMaps = getCommandRankMaps(options, terms)
+  return options
+    .filter((option) => rankMaps.every((rankMap) => rankMap.has(option)))
+    .sort((a, b) => {
+      const rankA = rankMaps.reduce((sum, rankMap) => sum + rankMap.get(a), 0)
+      const rankB = rankMaps.reduce((sum, rankMap) => sum + rankMap.get(b), 0)
+      if (rankA !== rankB) {
+        return rankA - rankB
+      }
+      return a.name.localeCompare(b.name)
+    })
+}

--- a/packages/extension/src/js/components/AutocompleteSearch/index.tsx
+++ b/packages/extension/src/js/components/AutocompleteSearch/index.tsx
@@ -16,13 +16,13 @@ import HistoryItemTab from 'components/Tab/HistoryItemTab'
 import Tab from 'stores/Tab'
 import { HistoryItem, getTabSearchKeys } from 'stores/SearchStore'
 import { openURL } from 'libs'
+import { filterCommandOptions } from './filterOptions'
 
 const SEARCH_PLACEHOLDER = 'Search tabs or URLs'
 const SEARCH_HINT = '/ focus · > commands'
 
 const commandFilter = (options, { inputValue }) => {
-  const keys = ['name', 'shortcut']
-  return matchSorter(options, inputValue.slice(1).trim(), { keys })
+  return filterCommandOptions(options, inputValue.slice(1).trim())
 }
 
 /**

--- a/packages/integration_test/test/interaction.test.ts
+++ b/packages/integration_test/test/interaction.test.ts
@@ -666,6 +666,35 @@ test.describe('The Extension page should', () => {
     expect(inputValue).toBe('')
   })
 
+  test('command search should match regardless of word order', async () => {
+    await openPages(browserContext, URLS)
+    await page.bringToFront()
+    await page.waitForTimeout(1000)
+
+    const searchInput = page.locator(
+      'input[placeholder*="Search tabs or URLs"]',
+    )
+    await expect(searchInput).toBeVisible()
+
+    const getCommandOptions = async (query: string) => {
+      await searchInput.click()
+      await searchInput.fill(query)
+      const options = page.locator('.MuiAutocomplete-option')
+      await expect(options.first()).toBeVisible()
+      return (await options.allTextContents()).map((text) =>
+        text.replace(/\s+/g, ' ').trim(),
+      )
+    }
+
+    const canonicalOptions = await getCommandOptions('>expand window')
+    const reorderedOptions = await getCommandOptions('>window expand')
+
+    expect(reorderedOptions).toEqual(canonicalOptions)
+    expect(
+      reorderedOptions.some((text) => text.includes('Expand all windows')),
+    ).toBe(true)
+  })
+
   test('close tab when click close button', async () => {
     await openPages(browserContext, URLS)
     await page.bringToFront()


### PR DESCRIPTION
## Summary
- make command search token-aware so reordered terms like `window expand` match the same commands as `expand window`
- keep command ranking stable by combining per-term match-sorter ranks
- add unit and Playwright regression coverage for the reordered-term search flow

## Testing
- pnpm --filter tab-manager-v2 test -- --runTestsByPath src/js/components/AutocompleteSearch/__tests__/filterOptions.test.ts
- pnpm --filter tab-manager-v2 build:chrome
- pnpm --filter integration-test test -- --grep "command search should match regardless of word order"
- pnpm exec eslint packages/extension/src/js/components/AutocompleteSearch/index.tsx packages/extension/src/js/components/AutocompleteSearch/filterOptions.ts packages/extension/src/js/components/AutocompleteSearch/__tests__/filterOptions.test.ts packages/integration_test/test/interaction.test.ts

## Notes
- Closes #2589
- This touches popup search code in a snapshot-sensitive area, so Ubuntu CI is still the remaining cross-platform verification step.