### PR TITLE
Fix ungrouped tab drops into existing groups

### DIFF
--- a/packages/extension/src/js/stores/DragStore.tsx
+++ b/packages/extension/src/js/stores/DragStore.tsx
@@ -2,6 +2,7 @@ import { makeAutoObservable } from 'mobx'
 import Store from 'stores'
 import Tab from './Tab'
 import log from 'libs/log'
+import { browser } from 'libs'
 
 export type DropSource = 'tab-row' | 'group-header' | 'window-zone'
 
@@ -9,6 +10,7 @@ export type DropAtOptions = {
   windowId: number
   index: number
   targetGroupId?: number
+  targetTabId?: number
   before?: boolean
   forceUngroup?: boolean
   source?: DropSource
@@ -189,11 +191,87 @@ export default class DragStore {
     return Math.max(0, Math.min(targetIndex - bounds.start, groupSize))
   }
 
+  getWindowTabsFromBrowser = async (windowId: number) => {
+    const tabs = await browser.tabs.query({ windowId })
+    return tabs.slice().sort((a, b) => {
+      return (a.index ?? 0) - (b.index ?? 0)
+    })
+  }
+
+  joinUngroupedTabsToTargetGroup = async ({
+    sources,
+    sourceTabIds,
+    windowId,
+    targetGroupId,
+    targetGroupOffset,
+    targetTabId,
+    before,
+    fallbackIndex,
+  }: {
+    sources: Tab[]
+    sourceTabIds: number[]
+    windowId: number
+    targetGroupId: number
+    targetGroupOffset: number
+    targetTabId?: number
+    before?: boolean
+    fallbackIndex: number
+  }) => {
+    const initialTabs = await this.getWindowTabsFromBrowser(windowId)
+    const initialBounds = this.getGroupBounds(initialTabs as any, targetGroupId)
+    const { moveTabs } = this.store.windowStore
+    const inSameWindow = sources.every((tab) => tab.windowId === windowId)
+
+    if (!initialBounds) {
+      if (!inSameWindow) {
+        await moveTabs(sources, windowId, fallbackIndex)
+      }
+      await this.store.tabGroupStore.groupTabs(sourceTabIds, targetGroupId)
+      return
+    }
+
+    const stageIndex = Math.min(initialBounds.end + 1, initialTabs.length)
+    let resolvedTargetGroupOffset = targetGroupOffset
+    if (typeof targetTabId === 'number') {
+      const actualTargetIndex = initialTabs.findIndex(
+        (tab) => tab.id === targetTabId,
+      )
+      if (actualTargetIndex > -1) {
+        const groupSize = initialBounds.end - initialBounds.start + 1
+        resolvedTargetGroupOffset = Math.max(
+          0,
+          Math.min(
+            actualTargetIndex - initialBounds.start + (before ? 0 : 1),
+            groupSize,
+          ),
+        )
+      }
+    }
+    await moveTabs(sources, windowId, stageIndex)
+    await this.store.tabGroupStore.groupTabs(sourceTabIds, targetGroupId)
+
+    const groupedTabs = await this.getWindowTabsFromBrowser(windowId)
+    const groupedBounds = this.getGroupBounds(groupedTabs as any, targetGroupId)
+    if (!groupedBounds) {
+      return
+    }
+
+    const finalIndex = Math.max(
+      groupedBounds.start,
+      Math.min(
+        groupedBounds.start + resolvedTargetGroupOffset,
+        groupedBounds.end + 1,
+      ),
+    )
+    await moveTabs(sources, windowId, finalIndex)
+  }
+
   drop = async (tab: Tab, before = true) => {
     return this.dropAt({
       windowId: tab.windowId,
       index: tab.index + (before ? 0 : 1),
       targetGroupId: tab.groupId,
+      targetTabId: tab.id,
       before,
       source: 'tab-row',
     })
@@ -271,29 +349,49 @@ export default class DragStore {
           await this.store.tabGroupStore.ungroupTabs(groupedSourceTabIds)
         }
         if (shouldJoinTargetGroup) {
-          const inSameWindow = sources.every((tab) => tab.windowId === windowId)
-          if (!inSameWindow) {
-            await moveTabs(sources, windowId, index)
+          const isUngroupedJoin =
+            this.isNoGroupId(sourceGroupId) && groupedSourceTabIds.length === 0
+          if (isUngroupedJoin) {
+            await this.joinUngroupedTabsToTargetGroup({
+              sources,
+              sourceTabIds,
+              windowId,
+              targetGroupId,
+              targetGroupOffset,
+              targetTabId: options.targetTabId,
+              before: options.before,
+              fallbackIndex: index,
+            })
+          } else {
+            const inSameWindow = sources.every(
+              (tab) => tab.windowId === windowId,
+            )
+            if (!inSameWindow) {
+              await moveTabs(sources, windowId, index)
+            }
+            const targetGroupTabIds = this.store.tabGroupStore
+              .getTabsForGroup(targetGroupId)
+              .slice()
+              .sort((a, b) => a.index - b.index)
+              .map((tab) => tab.id)
+            const sourceTabIdSet = new Set(sourceTabIds)
+            const preservedTargetTabIds = targetGroupTabIds.filter(
+              (tabId) => !sourceTabIdSet.has(tabId),
+            )
+            const insertOffset = Math.max(
+              0,
+              Math.min(targetGroupOffset, preservedTargetTabIds.length),
+            )
+            const orderedTabIds = [
+              ...preservedTargetTabIds.slice(0, insertOffset),
+              ...sourceTabIds,
+              ...preservedTargetTabIds.slice(insertOffset),
+            ]
+            await this.store.tabGroupStore.groupTabs(
+              orderedTabIds,
+              targetGroupId,
+            )
           }
-          const targetGroupTabIds = this.store.tabGroupStore
-            .getTabsForGroup(targetGroupId)
-            .slice()
-            .sort((a, b) => a.index - b.index)
-            .map((tab) => tab.id)
-          const sourceTabIdSet = new Set(sourceTabIds)
-          const preservedTargetTabIds = targetGroupTabIds.filter(
-            (tabId) => !sourceTabIdSet.has(tabId),
-          )
-          const insertOffset = Math.max(
-            0,
-            Math.min(targetGroupOffset, preservedTargetTabIds.length),
-          )
-          const orderedTabIds = [
-            ...preservedTargetTabIds.slice(0, insertOffset),
-            ...sourceTabIds,
-            ...preservedTargetTabIds.slice(insertOffset),
-          ]
-          await this.store.tabGroupStore.groupTabs(orderedTabIds, targetGroupId)
         } else {
           await moveTabs(sources, windowId, index)
           if (

--- a/packages/extension/src/js/stores/__tests__/DragStore.grouping.test.tsx
+++ b/packages/extension/src/js/stores/__tests__/DragStore.grouping.test.tsx
@@ -110,6 +110,15 @@ describe('DragStore with tab groups', () => {
         })),
       },
     } as any)
+    dragStore.getWindowTabsFromBrowser = jest
+      .fn()
+      .mockResolvedValueOnce([tab1, tab2, tab3, tab4])
+      .mockResolvedValueOnce([
+        tab2,
+        tab3,
+        tab4,
+        { ...tab1, groupId: 20, windowId: 1, index: 4 },
+      ])
     const draggedTab = {
       ...tab1,
       unhover: jest.fn(),
@@ -118,8 +127,19 @@ describe('DragStore with tab groups', () => {
     dragStore.dragStartTab(draggedTab as any)
     await dragStore.drop(tab3 as any, false)
 
-    expect(moveTabs).not.toHaveBeenCalled()
-    expect(groupTabs).toHaveBeenCalledWith([2, 3, 1, 4], 20)
+    expect(moveTabs).toHaveBeenNthCalledWith(
+      1,
+      [expect.objectContaining({ id: 1 })],
+      1,
+      4,
+    )
+    expect(groupTabs).toHaveBeenCalledWith([1], 20)
+    expect(moveTabs).toHaveBeenNthCalledWith(
+      2,
+      [expect.objectContaining({ id: 1 })],
+      1,
+      2,
+    )
     expect(moveGroup).not.toHaveBeenCalled()
   })
 
@@ -152,6 +172,14 @@ describe('DragStore with tab groups', () => {
         })),
       },
     } as any)
+    dragStore.getWindowTabsFromBrowser = jest
+      .fn()
+      .mockResolvedValueOnce([tab1, tab2, tab3])
+      .mockResolvedValueOnce([
+        tab2,
+        tab3,
+        { ...tab1, groupId: 20, windowId: 1, index: 3 },
+      ])
     const draggedTab = {
       ...tab1,
       unhover: jest.fn(),
@@ -160,8 +188,19 @@ describe('DragStore with tab groups', () => {
     dragStore.dragStartTab(draggedTab as any)
     await dragStore.drop(tab3 as any, false)
 
-    expect(moveTabs).not.toHaveBeenCalled()
-    expect(groupTabs).toHaveBeenCalledWith([2, 3, 1], 20)
+    expect(moveTabs).toHaveBeenNthCalledWith(
+      1,
+      [expect.objectContaining({ id: 1 })],
+      1,
+      3,
+    )
+    expect(groupTabs).toHaveBeenCalledWith([1], 20)
+    expect(moveTabs).toHaveBeenNthCalledWith(
+      2,
+      [expect.objectContaining({ id: 1 })],
+      1,
+      2,
+    )
   })
 
   it('dropAt forceUngroup should detach only dragged grouped tab', async () => {
@@ -245,6 +284,14 @@ describe('DragStore with tab groups', () => {
         })),
       },
     } as any)
+    dragStore.getWindowTabsFromBrowser = jest
+      .fn()
+      .mockResolvedValueOnce([tab1, tab2, tab3])
+      .mockResolvedValueOnce([
+        tab2,
+        tab3,
+        { ...tab1, groupId: 20, windowId: 1, index: 3 },
+      ])
     const draggedTab = {
       ...tab1,
       unhover: jest.fn(),
@@ -259,8 +306,80 @@ describe('DragStore with tab groups', () => {
       source: 'group-header',
     })
 
-    expect(moveTabs).not.toHaveBeenCalled()
-    expect(groupTabs).toHaveBeenCalledWith([1, 2, 3], 20)
+    expect(moveTabs).toHaveBeenNthCalledWith(
+      1,
+      [expect.objectContaining({ id: 1 })],
+      1,
+      3,
+    )
+    expect(groupTabs).toHaveBeenCalledWith([1], 20)
+    expect(moveTabs).toHaveBeenNthCalledWith(
+      2,
+      [expect.objectContaining({ id: 1 })],
+      1,
+      0,
+    )
+  })
+
+  it('drop into grouped target from another window should stage after group before joining', async () => {
+    process.env.TARGET_BROWSER = 'chrome'
+    const selection = new Map()
+    const sourceTab = { id: 1, groupId: -1, windowId: 2, index: 0 }
+    const tab2 = { id: 2, groupId: 20, windowId: 1, index: 1 }
+    const tab3 = { id: 3, groupId: 20, windowId: 1, index: 2 }
+    const tab4 = { id: 4, groupId: 20, windowId: 1, index: 3 }
+    const moveTabs = jest.fn(() => Promise.resolve())
+    const groupTabs = jest.fn(() => Promise.resolve())
+    const tabStore = setupTabStore(selection)
+    const dragStore = new DragStore({
+      tabStore,
+      tabGroupStore: {
+        getTabsForGroup: jest.fn(() => [tab2, tab3, tab4]),
+        groupTabs,
+        getNoGroupId: () => -1,
+        hasTabGroupsApi: () => true,
+        canMutateGroups: () => true,
+        canMoveGroups: () => true,
+      },
+      windowStore: {
+        suspend: jest.fn(),
+        resume: jest.fn(),
+        markLayoutDirtyIfNeeded: jest.fn(),
+        moveTabs,
+        getTargetWindow: jest.fn(() => ({
+          tabs: [tab2, tab3, tab4],
+        })),
+      },
+    } as any)
+    dragStore.getWindowTabsFromBrowser = jest
+      .fn()
+      .mockResolvedValueOnce([tab2, tab3, tab4])
+      .mockResolvedValueOnce([
+        tab2,
+        tab3,
+        tab4,
+        { ...sourceTab, groupId: 20, windowId: 1, index: 4 },
+      ])
+
+    dragStore.dragStartTab({
+      ...sourceTab,
+      unhover: jest.fn(),
+    } as any)
+    await dragStore.drop(tab3 as any, false)
+
+    expect(moveTabs).toHaveBeenNthCalledWith(
+      1,
+      [expect.objectContaining({ id: 1 })],
+      1,
+      3,
+    )
+    expect(groupTabs).toHaveBeenCalledWith([1], 20)
+    expect(moveTabs).toHaveBeenNthCalledWith(
+      2,
+      [expect.objectContaining({ id: 1 })],
+      1,
+      2,
+    )
   })
 
   it('full-group selection should use moveGroup fast path', async () => {

--- a/packages/integration_test/test/interaction.test.ts
+++ b/packages/integration_test/test/interaction.test.ts
@@ -916,7 +916,7 @@ test.describe('The Extension page should', () => {
           })
         ).sort((a, b) => a.index - b.index)
         const sourceTabId = tabs.find((tab) => tab.url === sourceUrl)?.id ?? -1
-        const dropTargetTabId = groupedTabs[1]?.id ?? -1
+        const dropTargetTabId = groupedTabs[2]?.id ?? -1
         return {
           sourceTabId,
           dropTargetTabId,
@@ -941,7 +941,7 @@ test.describe('The Extension page should', () => {
     await dragByTestId(page, {
       sourceTestId: `tab-row-${sourceTabId}`,
       targetTestId: `tab-row-${dropTargetTabId}`,
-      dropPosition: 'bottom',
+      dropPosition: 'top',
       targetUseParent: true,
     })
     await page.waitForTimeout(900)
@@ -967,6 +967,7 @@ test.describe('The Extension page should', () => {
           (tab) => tab.id === dropTargetTabId,
         )
         return {
+          groupUrls: groupTabs.map((tab) => tab.url),
           sourceGroupId: source?.groupId ?? chrome.tabGroups.TAB_GROUP_ID_NONE,
           groupCount: groupTabs.length,
           contiguous,
@@ -985,8 +986,147 @@ test.describe('The Extension page should', () => {
     expect(result.sourceGroupId).toBe(groupId)
     expect(result.groupCount).toBe(4)
     expect(result.contiguous).toBe(true)
+    expect(result.groupUrls).toEqual([
+      groupedUrls[0],
+      groupedUrls[1],
+      sourceUrl,
+      groupedUrls[2],
+    ])
     await expect(page.getByTestId(`tab-group-header-${groupId}`)).toHaveCount(1)
     await expect(page.getByTestId(`tab-group-count-${groupId}`)).toHaveText('4')
+  })
+
+  test('drop ungrouped tab from another window into grouped tabs should keep dropped order', async () => {
+    await page.evaluate(async () => {
+      await chrome.storage.local.set({
+        query: '',
+        showUnmatchedTab: true,
+      })
+    })
+    await page.reload()
+    await page.waitForTimeout(600)
+
+    const setup = await page.evaluate(async () => {
+      const sourceUrl = 'data:text/html,cross-drop-source'
+      const groupedUrls = [
+        'data:text/html,cross-drop-group-1',
+        'data:text/html,cross-drop-group-2',
+        'data:text/html,cross-drop-group-3',
+      ]
+      const sourceWindow = await chrome.windows.create({
+        url: sourceUrl,
+        focused: false,
+      })
+      const targetWindow = await chrome.windows.create({
+        url: groupedUrls[0],
+        focused: false,
+      })
+      if (
+        typeof sourceWindow.id !== 'number' ||
+        typeof targetWindow.id !== 'number'
+      ) {
+        return null
+      }
+
+      await chrome.tabs.create({
+        windowId: targetWindow.id,
+        url: groupedUrls[1],
+        active: false,
+      })
+      await chrome.tabs.create({
+        windowId: targetWindow.id,
+        url: groupedUrls[2],
+        active: false,
+      })
+      await new Promise((resolve) => setTimeout(resolve, 700))
+
+      const targetTabs = (
+        await chrome.tabs.query({
+          windowId: targetWindow.id,
+        })
+      ).sort((a, b) => a.index - b.index)
+      const groupedTabIds = groupedUrls.map(
+        (url) => targetTabs.find((tab) => tab.url === url)?.id ?? -1,
+      )
+      const groupId = await chrome.tabs.group({
+        tabIds: groupedTabIds,
+      })
+      await chrome.tabGroups.update(groupId, {
+        title: 'Cross Drop Group',
+        color: 'green',
+      })
+
+      const sourceTabs = await chrome.tabs.query({
+        windowId: sourceWindow.id,
+      })
+      const groupedTabs = (
+        await chrome.tabs.query({
+          groupId,
+        })
+      ).sort((a, b) => a.index - b.index)
+      return {
+        sourceUrl,
+        groupedUrls,
+        groupId,
+        sourceWindowId: sourceWindow.id,
+        targetWindowId: targetWindow.id,
+        sourceTabId: sourceTabs.find((tab) => tab.url === sourceUrl)?.id ?? -1,
+        dropTargetTabId: groupedTabs[2]?.id ?? -1,
+      }
+    })
+    expect(setup).toBeTruthy()
+    expect(setup!.sourceTabId).toBeGreaterThan(0)
+    expect(setup!.dropTargetTabId).toBeGreaterThan(0)
+
+    await page.waitForTimeout(700)
+    await page.reload()
+    await page.waitForTimeout(1200)
+    await waitForTestId(page, `tab-row-${setup!.sourceTabId}`)
+    await waitForTestId(page, `tab-row-${setup!.dropTargetTabId}`)
+
+    const sourceRow = page.getByTestId(`tab-row-${setup!.sourceTabId}`)
+    const targetRow = page.getByTestId(`tab-row-${setup!.dropTargetTabId}`)
+    await expect(sourceRow).toHaveCount(1)
+    await expect(targetRow).toHaveCount(1)
+
+    await dragByTestId(page, {
+      sourceTestId: `tab-row-${setup!.sourceTabId}`,
+      targetTestId: `tab-row-${setup!.dropTargetTabId}`,
+      dropPosition: 'top',
+      targetUseParent: true,
+    })
+    await page.waitForTimeout(1200)
+
+    const result = await page.evaluate(async (data) => {
+      const sourceTab = await chrome.tabs.get(data.sourceTabId)
+      const groupTabs = (
+        await chrome.tabs.query({
+          groupId: data.groupId,
+        })
+      ).sort((a, b) => a.index - b.index)
+      return {
+        sourceWindowId: sourceTab.windowId,
+        sourceGroupId: sourceTab.groupId,
+        groupedWindowId: groupTabs[0]?.windowId ?? -1,
+        groupUrls: groupTabs.map((tab) => tab.url),
+      }
+    }, setup)
+
+    expect(result.sourceWindowId).not.toBe(setup!.sourceWindowId)
+    expect(result.sourceWindowId).toBe(result.groupedWindowId)
+    expect(result.sourceGroupId).toBe(setup!.groupId)
+    expect(result.groupUrls).toEqual([
+      setup!.groupedUrls[0],
+      setup!.groupedUrls[1],
+      setup!.sourceUrl,
+      setup!.groupedUrls[2],
+    ])
+    await expect(
+      page.getByTestId(`tab-group-header-${setup!.groupId}`),
+    ).toHaveCount(1)
+    await expect(
+      page.getByTestId(`tab-group-count-${setup!.groupId}`),
+    ).toHaveText('4')
   })
 
   test('drag single grouped tab should reorder within same group', async () => {


### PR DESCRIPTION
## Summary
- stage ungrouped tabs adjacent to the target group before joining it so Chrome does not reject cross-window drops
- recompute the live target insertion slot from browser tab order before the final move so same-window drops land in the intended place
- add unit and integration coverage for same-window and cross-window middle insertion into grouped tabs

## Testing
- pnpm --filter tab-manager-v2 test -- DragStore.grouping.test.tsx
- pnpm --filter tab-manager-v2 build:chrome
- pnpm --filter integration-test exec playwright test test/interaction.test.ts --project=chromium -g "drop ungrouped tab into grouped tabs should keep one intact target group|drop ungrouped tab from another window into grouped tabs should keep dropped order"

## Release Please Override

```txt
BEGIN_COMMIT_OVERRIDE
fix: keep target groups intact when dropping ungrouped tabs
fix: preserve drop order when moving ungrouped tabs into grouped tabs
END_COMMIT_OVERRIDE
```
