### PR TITLE
fix: track active window for full-page extension tab

### DIFF
--- a/packages/extension/src/js/background/TabHistory.tsx
+++ b/packages/extension/src/js/background/TabHistory.tsx
@@ -2,7 +2,7 @@ import {
   activateTab,
   setLastFocusedWindowId,
   browser,
-  isSelfPopupTab,
+  isSelfPopup,
   setSelfPopupActive,
 } from 'libs'
 import actions from 'libs/actions'
@@ -157,12 +157,15 @@ export default class TabHistory {
       return setSelfPopupActive(false)
     }
     try {
-      const [tab] = await browser.tabs.query({ active: true, windowId })
+      const win = await browser.windows.get(windowId, {
+        populate: true,
+      })
+      const tab = (win?.tabs || []).find((candidate) => candidate.active)
       if (!tab) {
         log.debug('onFocusChanged does nothing since no tab')
         return setSelfPopupActive(false)
       }
-      const isPopupWindow = isSelfPopupTab(tab)
+      const isPopupWindow = !!win && isSelfPopup(win)
       if (isPopupWindow) {
         log.debug('onFocusChanged ignore self popup window', {
           tab,

--- a/packages/extension/src/js/background/__tests__/TabHistory.test.tsx
+++ b/packages/extension/src/js/background/__tests__/TabHistory.test.tsx
@@ -1,0 +1,98 @@
+import TabHistory from '../TabHistory'
+import { browser, setLastFocusedWindowId, setSelfPopupActive } from 'libs'
+import { setBrowserIcon } from 'libs/verify'
+
+const popupUrl =
+  'chrome-extension://ehkonpddnilnaghlnblmghpdobeomohi/popup.html?not_popup=1'
+
+jest.mock('libs', () => ({
+  browser: {
+    tabs: {
+      onActivated: {
+        addListener: jest.fn(),
+      },
+      onRemoved: {
+        addListener: jest.fn(),
+      },
+      query: jest.fn(),
+      get: jest.fn(),
+    },
+    windows: {
+      onFocusChanged: {
+        addListener: jest.fn(),
+      },
+      get: jest.fn(),
+    },
+    storage: {
+      local: {
+        get: jest.fn(() => Promise.resolve({ tabHistory: [] })),
+        set: jest.fn(() => Promise.resolve()),
+      },
+    },
+  },
+  activateTab: jest.fn(),
+  setLastFocusedWindowId: jest.fn(),
+  setSelfPopupActive: jest.fn(),
+  isSelfPopupTab: jest.fn(
+    (tab) => tab.url === popupUrl || tab.pendingUrl === popupUrl,
+  ),
+  isSelfPopup: jest.fn(({ type, tabs = [] }) => {
+    if (type !== 'popup' || tabs.length !== 1) {
+      return false
+    }
+    const [tab] = tabs
+    return tab.url === popupUrl || tab.pendingUrl === popupUrl
+  }),
+}))
+
+jest.mock('libs/verify', () => ({
+  setBrowserIcon: jest.fn(),
+}))
+
+describe('TabHistory.onFocusChanged', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    ;(browser.storage.local.get as jest.Mock).mockResolvedValue({
+      tabHistory: [],
+    })
+  })
+
+  it('records last focused window when popup.html?not_popup=1 is opened in a normal window', async () => {
+    ;(browser.tabs.query as jest.Mock).mockResolvedValue([
+      {
+        id: 7,
+        active: true,
+        windowId: 42,
+        url: popupUrl,
+      },
+    ])
+    ;(browser.windows.get as jest.Mock).mockResolvedValue({
+      id: 42,
+      type: 'normal',
+      tabs: [
+        {
+          id: 7,
+          active: true,
+          windowId: 42,
+          url: popupUrl,
+        },
+      ],
+    })
+
+    const tabHistory = new TabHistory()
+
+    await tabHistory.onFocusChanged(42)
+
+    expect(setBrowserIcon).toHaveBeenCalled()
+    expect(setSelfPopupActive).not.toHaveBeenCalledWith(true)
+    expect(setLastFocusedWindowId).toHaveBeenCalledWith(42)
+    expect(tabHistory.tabHistory).toEqual([
+      expect.objectContaining({
+        id: 7,
+        tabId: 7,
+        windowId: 42,
+        url: popupUrl,
+      }),
+    ])
+  })
+})

--- a/packages/extension/src/js/stores/WindowStore.tsx
+++ b/packages/extension/src/js/stores/WindowStore.tsx
@@ -1272,10 +1272,27 @@ export default class WindowsStore {
     const wasInitialLoading = this.initialLoading
     const policy: LoadRepackPolicy =
       repackPolicy || (wasInitialLoading ? 'always' : 'if-clean')
-    const windows = await browser.windows.getAll({
-      populate: true,
-    })
-    this.lastFocusedWindowId = await getLastFocusedWindowId()
+    const [windows, storedLastFocusedWindowId, currentWindow] =
+      await Promise.all([
+        browser.windows.getAll({
+          populate: true,
+        }),
+        getLastFocusedWindowId(),
+        browser.windows
+          .getCurrent({
+            populate: true,
+          })
+          .catch(() => null),
+      ])
+    const currentFocusedWindowId =
+      currentWindow &&
+      currentWindow.focused &&
+      !isSelfPopup(currentWindow) &&
+      typeof currentWindow.id === 'number'
+        ? currentWindow.id
+        : null
+    this.lastFocusedWindowId =
+      currentFocusedWindowId ?? storedLastFocusedWindowId
     log.debug('lastFocusedWindowId:', this.lastFocusedWindowId)
     const previousWindowOrder = new Map(
       this.windows.map((win, index) => [win.id, index]),

--- a/packages/extension/src/js/stores/__tests__/WindowStore.test.tsx
+++ b/packages/extension/src/js/stores/__tests__/WindowStore.test.tsx
@@ -15,6 +15,7 @@ jest.mock('libs', () => ({
       },
       getAll: jest.fn(() => Promise.resolve([])),
       get: jest.fn(() => Promise.resolve({ id: 1, tabs: [] })),
+      getCurrent: jest.fn(() => Promise.resolve(null)),
       update: jest.fn(),
     },
     tabs: {
@@ -278,6 +279,56 @@ describe('WindowStore layout policy', () => {
 
     expect(windowStore.columnLayout).toEqual(columnLayoutBefore)
     expect(windowStore.layoutDirty).toBe(true)
+  })
+
+  it('prefers the current normal window over stale persisted focus during foreground refresh', async () => {
+    const windowStore = createWindowStore()
+    ;(getLastFocusedWindowId as jest.Mock).mockResolvedValueOnce(1)
+    ;(browser.windows.getCurrent as jest.Mock).mockResolvedValueOnce({
+      id: 2,
+      focused: true,
+      type: 'normal',
+      tabs: [
+        {
+          id: 21,
+          active: true,
+          index: 0,
+          windowId: 2,
+          title: 'Extension',
+          url: 'chrome-extension://example/popup.html?not_popup=1',
+        },
+      ],
+    })
+    ;(browser.windows.getAll as jest.Mock).mockResolvedValueOnce([
+      {
+        id: 1,
+        type: 'normal',
+        tabs: [
+          { id: 11, index: 0, windowId: 1, title: '1', url: 'about:blank' },
+        ],
+      },
+      {
+        id: 2,
+        type: 'normal',
+        tabs: [
+          {
+            id: 21,
+            active: true,
+            index: 0,
+            windowId: 2,
+            title: 'Extension',
+            url: 'chrome-extension://example/popup.html?not_popup=1',
+          },
+        ],
+      },
+    ])
+
+    await windowStore.loadAllWindows({
+      repackPolicy: 'never',
+      reason: 'window-focus',
+    })
+
+    expect(windowStore.lastFocusedWindowId).toBe(2)
   })
 
   it('sync keeps existing window order when browser data has same windows', async () => {


### PR DESCRIPTION
## Summary

- fix active-window tracking when `popup.html?not_popup=1` is opened in a normal browser tab
- prefer the current focused normal window during foreground refresh and add regressions for both focus-tracking paths

## Testing

- `pnpm exec jest --maxWorkers=1 --runTestsByPath src/js/stores/__tests__/WindowStore.test.tsx src/js/background/__tests__/TabHistory.test.tsx`
- `pnpm build:chrome`

## Release Notes

- Fix active window highlighting for the full-page extension view.
