### PR TITLE
fix: preserve grouped drag-and-drop semantics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ playwright-report
 test-results
 .playwright-mcp/
 .tmp/
+.worktrees/
 
 # macOS
 .DS_Store

--- a/packages/extension/src/js/components/TabGroup/GroupRow.tsx
+++ b/packages/extension/src/js/components/TabGroup/GroupRow.tsx
@@ -175,12 +175,13 @@ export default observer((props: Props) => {
         })
         return
       }
+      const fromGroupHeaderDrag = dragStore.dragSource === 'group-header'
       dragStore.dropAt({
         windowId: row.windowId,
         index: groupStartIndex,
         targetGroupId: row.groupId,
         before: true,
-        source: 'group-header',
+        source: fromGroupHeaderDrag ? 'group-header' : 'tab-row',
       })
     },
     collect: (monitor) => ({

--- a/packages/extension/src/js/components/TabGroup/GroupRow.tsx
+++ b/packages/extension/src/js/components/TabGroup/GroupRow.tsx
@@ -175,13 +175,12 @@ export default observer((props: Props) => {
         })
         return
       }
-      const fromGroupHeaderDrag = dragStore.dragSource === 'group-header'
       dragStore.dropAt({
         windowId: row.windowId,
         index: groupStartIndex,
         targetGroupId: row.groupId,
         before: true,
-        source: fromGroupHeaderDrag ? 'group-header' : 'tab-row',
+        source: 'group-header',
       })
     },
     collect: (monitor) => ({

--- a/packages/extension/src/js/components/TabGroup/__tests__/GroupRow.test.tsx
+++ b/packages/extension/src/js/components/TabGroup/__tests__/GroupRow.test.tsx
@@ -4,8 +4,12 @@ import { AppThemeContext, lightAppTheme } from 'libs/appTheme'
 import { StoreContext } from 'components/hooks/useStore'
 import GroupRow from '../GroupRow'
 
+const mockUseDrop = jest.fn()
+const mockDrop = jest.fn()
+let lastDropSpec: any = null
+
 jest.mock('react-dnd', () => ({
-  useDrop: () => [{ canDrop: false, isOver: false }, jest.fn()],
+  useDrop: (...args) => mockUseDrop(...args),
 }))
 jest.mock('../GroupEditorPopover', () => () => null)
 jest.mock('../GroupDragHandle', () => () => (
@@ -29,7 +33,109 @@ jest.mock(
 )
 jest.mock('components/DropIndicator', () => () => null)
 
+const mockHeaderRect = (node: HTMLDivElement) => {
+  Object.defineProperty(node, 'getBoundingClientRect', {
+    configurable: true,
+    value: () => ({
+      top: 0,
+      left: 0,
+      right: 200,
+      bottom: 40,
+      width: 200,
+      height: 40,
+      x: 0,
+      y: 0,
+      toJSON: () => {},
+    }),
+  })
+}
+
+const renderGroupRow = (
+  dragSource: 'tab-row' | 'group-header',
+  dropAt: any,
+) => {
+  const groupRow = {
+    isFocused: false,
+    focusRequestId: 0,
+    shouldMoveDomFocus: true,
+    shouldRevealOnFocus: false,
+    setNodeRef: jest.fn(),
+    groupId: 100,
+    windowId: 1,
+  }
+  const store = {
+    tabGroupStore: {
+      getTabGroup: jest.fn(() => ({
+        id: 100,
+        color: 'blue',
+        title: 'My group',
+        collapsed: false,
+      })),
+      getTabsForGroup: jest.fn(() => [
+        { id: 1, index: 0 },
+        { id: 2, index: 1 },
+      ]),
+      toggleCollapsed: jest.fn(),
+      canMutateGroups: jest.fn(() => true),
+    },
+    searchStore: {
+      _query: '',
+    },
+    windowStore: {
+      getDuplicateTabsToRemoveCount: jest.fn(() => 0),
+      windows: [{ id: 1, canDrop: true }],
+    },
+    dragStore: {
+      dragging: true,
+      dragSource,
+      dropAt,
+    },
+    focusStore: {
+      focus: jest.fn(),
+      shouldRevealNode: jest.fn(() => false),
+    },
+    userStore: {
+      uiPreset: 'modern',
+    },
+  } as any
+  const row = {
+    kind: 'group' as const,
+    groupId: 100,
+    windowId: 1,
+    color: 'blue',
+    collapsed: false,
+    tabIds: [1, 2],
+    matchedCount: 2,
+  }
+  const win = {
+    id: 1,
+    getGroupRow: jest.fn(() => groupRow),
+  } as any
+
+  render(
+    <StoreContext.Provider value={store}>
+      <AppThemeContext.Provider value={lightAppTheme}>
+        <GroupRow row={row} win={win} />
+      </AppThemeContext.Provider>
+    </StoreContext.Provider>,
+  )
+
+  const dropNode = mockDrop.mock.calls[0][0] as HTMLDivElement
+  mockHeaderRect(dropNode)
+  return { groupRow, dropNode, dropAt }
+}
+
 describe('GroupRow', () => {
+  beforeEach(() => {
+    mockDrop.mockClear()
+    mockUseDrop.mockReset()
+    lastDropSpec = null
+    mockUseDrop.mockImplementation((spec) => {
+      lastDropSpec = spec
+      return [{ canDrop: true, isOver: false }, mockDrop]
+    })
+  })
+
   it('keeps native toggle focus while syncing logical focus state', () => {
     const focus = jest.fn()
     const groupRow = {
@@ -101,6 +207,49 @@ describe('GroupRow', () => {
       origin: 'keyboard',
       reveal: false,
       moveDomFocus: false,
+    })
+  })
+
+  it('uses the active drag source for centered group-header drops', () => {
+    const dropAt = jest.fn()
+    renderGroupRow('tab-row', dropAt)
+
+    expect(lastDropSpec).not.toBeNull()
+    lastDropSpec.drop(
+      {},
+      {
+        didDrop: () => false,
+        getClientOffset: () => ({ x: 20, y: 25 }),
+      },
+    )
+
+    expect(dropAt).toHaveBeenCalledWith({
+      windowId: 1,
+      index: 0,
+      targetGroupId: 100,
+      before: true,
+      source: 'tab-row',
+    })
+  })
+
+  it('keeps group-header before-zone drops separate', () => {
+    const dropAt = jest.fn()
+    renderGroupRow('group-header', dropAt)
+
+    expect(lastDropSpec).not.toBeNull()
+    lastDropSpec.drop(
+      {},
+      {
+        didDrop: () => false,
+        getClientOffset: () => ({ x: 20, y: 1 }),
+      },
+    )
+
+    expect(dropAt).toHaveBeenCalledWith({
+      windowId: 1,
+      index: 0,
+      forceUngroup: false,
+      source: 'group-header',
     })
   })
 })

--- a/packages/extension/src/js/components/TabGroup/__tests__/GroupRow.test.tsx
+++ b/packages/extension/src/js/components/TabGroup/__tests__/GroupRow.test.tsx
@@ -210,7 +210,7 @@ describe('GroupRow', () => {
     })
   })
 
-  it('uses the active drag source for centered group-header drops', () => {
+  it('treats centered group-header drops as explicit merge intent', () => {
     const dropAt = jest.fn()
     renderGroupRow('tab-row', dropAt)
 
@@ -228,7 +228,7 @@ describe('GroupRow', () => {
       index: 0,
       targetGroupId: 100,
       before: true,
-      source: 'tab-row',
+      source: 'group-header',
     })
   })
 

--- a/packages/extension/src/js/components/Window/WindowDropZone.tsx
+++ b/packages/extension/src/js/components/Window/WindowDropZone.tsx
@@ -23,10 +23,11 @@ export default observer((props: Props) => {
       if (monitor.didDrop()) {
         return
       }
+      const forceUngroup = dragStore.dragSource !== 'group-header'
       dragStore.dropAt({
         windowId: win.id,
         index: position === 'top' ? 0 : win.tabs.length,
-        forceUngroup: true,
+        forceUngroup,
         source: 'window-zone',
       })
     },

--- a/packages/extension/src/js/components/Window/__tests__/WindowDropZone.test.tsx
+++ b/packages/extension/src/js/components/Window/__tests__/WindowDropZone.test.tsx
@@ -1,0 +1,72 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import { StoreContext } from 'components/hooks/useStore'
+import WindowDropZone from '../WindowDropZone'
+
+const mockUseDrop = jest.fn()
+const mockDrop = jest.fn()
+let lastDropSpec: any = null
+
+jest.mock('react-dnd', () => ({
+  useDrop: (...args) => mockUseDrop(...args),
+}))
+
+describe('WindowDropZone', () => {
+  beforeEach(() => {
+    mockDrop.mockClear()
+    mockUseDrop.mockReset()
+    lastDropSpec = null
+    mockUseDrop.mockImplementation((spec) => {
+      lastDropSpec = spec
+      return [{ canDrop: false, isOver: false }, mockDrop]
+    })
+  })
+
+  it('preserves group-header drags but keeps tab-row drags ungrouped', () => {
+    const dragStore = {
+      dragSource: 'group-header',
+      dropAt: jest.fn(),
+    }
+    const win = {
+      id: 7,
+      canDrop: true,
+      tabs: [{ id: 1 }, { id: 2 }],
+    } as any
+    const store = {
+      dragStore,
+    } as any
+
+    const { rerender } = render(
+      <StoreContext.Provider value={store}>
+        <WindowDropZone win={win} position="bottom" />
+      </StoreContext.Provider>,
+    )
+
+    expect(lastDropSpec).not.toBeNull()
+    lastDropSpec.drop({}, { didDrop: () => false })
+    expect(dragStore.dropAt).toHaveBeenCalledWith({
+      windowId: 7,
+      index: 2,
+      forceUngroup: false,
+      source: 'window-zone',
+    })
+
+    dragStore.dropAt.mockClear()
+    dragStore.dragSource = 'tab-row'
+
+    rerender(
+      <StoreContext.Provider value={store}>
+        <WindowDropZone win={win} position="bottom" />
+      </StoreContext.Provider>,
+    )
+
+    expect(lastDropSpec).not.toBeNull()
+    lastDropSpec.drop({}, { didDrop: () => false })
+    expect(dragStore.dropAt).toHaveBeenCalledWith({
+      windowId: 7,
+      index: 2,
+      forceUngroup: true,
+      source: 'window-zone',
+    })
+  })
+})

--- a/packages/extension/src/js/libs/__tests__/index.test.tsx
+++ b/packages/extension/src/js/libs/__tests__/index.test.tsx
@@ -1,5 +1,6 @@
 const mockTabsUpdate = jest.fn(() => Promise.resolve())
 const mockTabsMove = jest.fn(() => Promise.resolve())
+const mockTabsGet = jest.fn()
 const mockTabsQuery = jest.fn()
 const mockTabsGroup = jest.fn()
 const mockTabsUngroup = jest.fn()
@@ -25,6 +26,7 @@ jest.mock('webextension-polyfill', () => ({
       },
     },
     tabs: {
+      get: mockTabsGet,
       update: mockTabsUpdate,
       move: mockTabsMove,
       query: mockTabsQuery,
@@ -60,6 +62,7 @@ const makeTab = (
 
 describe('ItemTypes', () => {
   beforeEach(() => {
+    mockTabsGet.mockReset()
     mockTabsUpdate.mockClear()
     mockTabsMove.mockClear()
     mockTabsQuery.mockReset()
@@ -72,6 +75,7 @@ describe('ItemTypes', () => {
 
     mockWindowsCreate.mockResolvedValue({ id: 99 })
     mockWindowsUpdate.mockResolvedValue(undefined)
+    mockTabsGet.mockResolvedValue(null)
     mockTabsQuery.mockResolvedValue([])
     mockTabsGroup.mockResolvedValue(70)
     mockTabsUngroup.mockResolvedValue(undefined)
@@ -97,8 +101,23 @@ describe('ItemTypes', () => {
   })
 
   it('moves a fully-selected tab group into a fresh window without ungrouping it', async () => {
-    const tabs = [makeTab(1, 1, 0, 10), makeTab(2, 1, 1, 10)]
-    mockTabsQuery.mockResolvedValue(tabs)
+    const tabs = [
+      { id: 1, pinned: false },
+      { id: 2, pinned: false },
+    ]
+    mockTabsGet.mockImplementation(async (id: number) => {
+      if (id === 1) {
+        return makeTab(1, 1, 0, 10)
+      }
+      if (id === 2) {
+        return makeTab(2, 1, 1, 10)
+      }
+      return null
+    })
+    mockTabsQuery.mockResolvedValue([
+      makeTab(1, 1, 0, 10),
+      makeTab(2, 1, 1, 10),
+    ])
     mockTabGroupsGet.mockResolvedValue({
       id: 10,
       title: 'Team',
@@ -128,12 +147,30 @@ describe('ItemTypes', () => {
 
   it('recreates grouped selections when mixed with ungrouped tabs in a new window', async () => {
     const tabs = [
-      makeTab(1, 1, 0, -1),
-      makeTab(2, 1, 1, 10),
-      makeTab(3, 1, 2, 10),
-      makeTab(4, 1, 3, 20),
-      makeTab(5, 1, 4, -1),
+      { id: 1, pinned: false },
+      { id: 2, pinned: false },
+      { id: 3, pinned: false },
+      { id: 4, pinned: false },
+      { id: 5, pinned: false },
     ]
+    mockTabsGet.mockImplementation(async (id: number) => {
+      if (id === 1) {
+        return makeTab(1, 1, 0, -1)
+      }
+      if (id === 2) {
+        return makeTab(2, 1, 1, 10)
+      }
+      if (id === 3) {
+        return makeTab(3, 1, 2, 10)
+      }
+      if (id === 4) {
+        return makeTab(4, 1, 3, 20)
+      }
+      if (id === 5) {
+        return makeTab(5, 1, 4, -1)
+      }
+      return null
+    })
     mockTabsQuery.mockResolvedValue([
       makeTab(1, 1, 0, -1),
       makeTab(2, 1, 1, 10),
@@ -181,6 +218,84 @@ describe('ItemTypes', () => {
       expect.any(Number),
       expect.objectContaining({ title: 'Partial' }),
     )
+  })
+
+  it('hydrates runtime-shaped tabs before preserving whole groups and detaching partial fragments in a new window', async () => {
+    const tabs = [
+      { id: 1, pinned: false },
+      { id: 2, pinned: false },
+      { id: 3, pinned: false },
+      { id: 4, pinned: false },
+    ]
+    mockTabsGet.mockImplementation(async (id: number) => {
+      if (id === 1) {
+        return makeTab(1, 1, 0, -1)
+      }
+      if (id === 2) {
+        return makeTab(2, 1, 1, 10)
+      }
+      if (id === 3) {
+        return makeTab(3, 1, 2, 10)
+      }
+      if (id === 4) {
+        return makeTab(4, 1, 3, 20)
+      }
+      return null
+    })
+    mockTabsQuery.mockResolvedValue([
+      makeTab(1, 1, 0, -1),
+      makeTab(2, 1, 1, 10),
+      makeTab(3, 1, 2, 10),
+      makeTab(4, 1, 3, 20),
+      makeTab(5, 1, 4, 20),
+    ])
+    mockTabGroupsGet.mockImplementation(async (groupId: number) => {
+      if (groupId === 10) {
+        return {
+          id: 10,
+          title: 'Team',
+          color: 'green',
+          collapsed: false,
+          windowId: 1,
+        }
+      }
+      if (groupId === 20) {
+        return {
+          id: 20,
+          title: 'Partial',
+          color: 'red',
+          collapsed: true,
+          windowId: 1,
+        }
+      }
+      return null
+    })
+    mockTabsGroup.mockResolvedValueOnce(71)
+
+    await createWindow(tabs as any)
+
+    expect(mockWindowsCreate).toHaveBeenCalledWith({ tabId: 1 })
+    expect(mockTabsMove).toHaveBeenNthCalledWith(1, 2, {
+      windowId: 99,
+      index: -1,
+    })
+    expect(mockTabsMove).toHaveBeenNthCalledWith(2, 3, {
+      windowId: 99,
+      index: -1,
+    })
+    expect(mockTabsMove).toHaveBeenNthCalledWith(3, 4, {
+      windowId: 99,
+      index: -1,
+    })
+    expect(mockTabsUngroup).toHaveBeenCalledWith([4])
+    expect(mockTabsGroup).toHaveBeenCalledWith({
+      tabIds: [2, 3],
+    })
+    expect(mockTabGroupsUpdate).toHaveBeenCalledWith(71, {
+      title: 'Team',
+      color: 'green',
+      collapsed: false,
+    })
   })
 
   it('preserves multiple whole groups in visible order when opening a new window', async () => {

--- a/packages/extension/src/js/libs/__tests__/index.test.tsx
+++ b/packages/extension/src/js/libs/__tests__/index.test.tsx
@@ -1,5 +1,12 @@
 const mockTabsUpdate = jest.fn(() => Promise.resolve())
 const mockTabsMove = jest.fn(() => Promise.resolve())
+const mockTabsQuery = jest.fn()
+const mockTabsGroup = jest.fn()
+const mockTabsUngroup = jest.fn()
+const mockTabGroupsGet = jest.fn()
+const mockTabGroupsUpdate = jest.fn()
+const mockWindowsCreate = jest.fn()
+const mockWindowsUpdate = jest.fn()
 
 jest.mock('webextension-polyfill', () => ({
   __esModule: true,
@@ -20,20 +27,56 @@ jest.mock('webextension-polyfill', () => ({
     tabs: {
       update: mockTabsUpdate,
       move: mockTabsMove,
+      query: mockTabsQuery,
+      group: mockTabsGroup,
+      ungroup: mockTabsUngroup,
+    },
+    tabGroups: {
+      get: mockTabGroupsGet,
+      update: mockTabGroupsUpdate,
+      TAB_GROUP_ID_NONE: -1,
     },
     windows: {
-      create: jest.fn(),
-      update: jest.fn(),
+      create: mockWindowsCreate,
+      update: mockWindowsUpdate,
     },
   },
 }))
 
-import { ItemTypes, moveTabs } from 'libs'
+import { ItemTypes, createWindow, moveTabs } from 'libs'
+
+const makeTab = (
+  id: number,
+  windowId: number,
+  index: number,
+  groupId = -1,
+) => ({
+  id,
+  windowId,
+  index,
+  groupId,
+  pinned: false,
+})
 
 describe('ItemTypes', () => {
   beforeEach(() => {
     mockTabsUpdate.mockClear()
     mockTabsMove.mockClear()
+    mockTabsQuery.mockReset()
+    mockTabsGroup.mockReset()
+    mockTabsUngroup.mockReset()
+    mockTabGroupsGet.mockReset()
+    mockTabGroupsUpdate.mockReset()
+    mockWindowsCreate.mockReset()
+    mockWindowsUpdate.mockClear()
+
+    mockWindowsCreate.mockResolvedValue({ id: 99 })
+    mockWindowsUpdate.mockResolvedValue(undefined)
+    mockTabsQuery.mockResolvedValue([])
+    mockTabsGroup.mockResolvedValue(70)
+    mockTabsUngroup.mockResolvedValue(undefined)
+    mockTabGroupsGet.mockResolvedValue(null)
+    mockTabGroupsUpdate.mockResolvedValue(null)
   })
 
   it('has tab type', () => {
@@ -51,5 +94,166 @@ describe('ItemTypes', () => {
     expect(mockTabsUpdate.mock.invocationCallOrder[0]).toBeLessThan(
       mockTabsMove.mock.invocationCallOrder[0],
     )
+  })
+
+  it('moves a fully-selected tab group into a fresh window without ungrouping it', async () => {
+    const tabs = [makeTab(1, 1, 0, 10), makeTab(2, 1, 1, 10)]
+    mockTabsQuery.mockResolvedValue(tabs)
+    mockTabGroupsGet.mockResolvedValue({
+      id: 10,
+      title: 'Team',
+      color: 'blue',
+      collapsed: true,
+      windowId: 1,
+    })
+    mockTabsGroup.mockResolvedValueOnce(71)
+
+    await createWindow(tabs as any)
+
+    expect(mockWindowsCreate).toHaveBeenCalledWith({ tabId: 1 })
+    expect(mockTabsMove).toHaveBeenNthCalledWith(1, 2, {
+      windowId: 99,
+      index: -1,
+    })
+    expect(mockTabsUngroup).not.toHaveBeenCalled()
+    expect(mockTabsGroup).toHaveBeenCalledWith({
+      tabIds: [1, 2],
+    })
+    expect(mockTabGroupsUpdate).toHaveBeenCalledWith(71, {
+      title: 'Team',
+      color: 'blue',
+      collapsed: true,
+    })
+  })
+
+  it('recreates grouped selections when mixed with ungrouped tabs in a new window', async () => {
+    const tabs = [
+      makeTab(1, 1, 0, -1),
+      makeTab(2, 1, 1, 10),
+      makeTab(3, 1, 2, 10),
+      makeTab(4, 1, 3, 20),
+      makeTab(5, 1, 4, -1),
+    ]
+    mockTabsQuery.mockResolvedValue([
+      makeTab(1, 1, 0, -1),
+      makeTab(2, 1, 1, 10),
+      makeTab(3, 1, 2, 10),
+      makeTab(4, 1, 3, 20),
+      makeTab(6, 1, 4, 20),
+      makeTab(5, 1, 5, -1),
+    ])
+    mockTabGroupsGet.mockImplementation(async (groupId: number) => {
+      if (groupId === 10) {
+        return {
+          id: 10,
+          title: 'Team',
+          color: 'green',
+          collapsed: false,
+          windowId: 1,
+        }
+      }
+      if (groupId === 20) {
+        return {
+          id: 20,
+          title: 'Partial',
+          color: 'red',
+          collapsed: true,
+          windowId: 1,
+        }
+      }
+      return null
+    })
+    mockTabsGroup.mockResolvedValueOnce(71)
+
+    await createWindow(tabs as any)
+
+    expect(mockTabsMove.mock.calls.map(([id]) => id)).toEqual([2, 3, 4, 5])
+    expect(mockTabsUngroup).toHaveBeenCalledWith([4])
+    expect(mockTabsGroup).toHaveBeenCalledWith({
+      tabIds: [2, 3],
+    })
+    expect(mockTabGroupsUpdate).toHaveBeenCalledWith(71, {
+      title: 'Team',
+      color: 'green',
+      collapsed: false,
+    })
+    expect(mockTabGroupsUpdate).not.toHaveBeenCalledWith(
+      expect.any(Number),
+      expect.objectContaining({ title: 'Partial' }),
+    )
+  })
+
+  it('preserves multiple whole groups in visible order when opening a new window', async () => {
+    const tabs = [
+      makeTab(1, 1, 0, 10),
+      makeTab(2, 1, 1, 10),
+      makeTab(3, 1, 2, -1),
+      makeTab(4, 1, 3, 20),
+      makeTab(5, 1, 4, 20),
+    ]
+    mockTabsQuery.mockResolvedValue(tabs)
+    mockTabGroupsGet.mockImplementation(async (groupId: number) => {
+      if (groupId === 10) {
+        return {
+          id: 10,
+          title: 'First',
+          color: 'yellow',
+          collapsed: false,
+          windowId: 1,
+        }
+      }
+      if (groupId === 20) {
+        return {
+          id: 20,
+          title: 'Second',
+          color: 'purple',
+          collapsed: true,
+          windowId: 1,
+        }
+      }
+      return null
+    })
+    mockTabsGroup.mockResolvedValueOnce(71).mockResolvedValueOnce(72)
+
+    await createWindow(tabs as any)
+
+    expect(mockTabsMove.mock.calls.map(([id]) => id)).toEqual([2, 3, 4, 5])
+    expect(mockTabsGroup.mock.calls[0][0]).toEqual({
+      tabIds: [1, 2],
+    })
+    expect(mockTabsGroup.mock.calls[1][0]).toEqual({
+      tabIds: [4, 5],
+    })
+    expect(mockTabGroupsUpdate).toHaveBeenNthCalledWith(1, 71, {
+      title: 'First',
+      color: 'yellow',
+      collapsed: false,
+    })
+    expect(mockTabGroupsUpdate).toHaveBeenNthCalledWith(2, 72, {
+      title: 'Second',
+      color: 'purple',
+      collapsed: true,
+    })
+  })
+
+  it('restores title, color, and collapsed state on recreated groups', async () => {
+    const tabs = [makeTab(1, 1, 0, 10), makeTab(2, 1, 1, 10)]
+    mockTabsQuery.mockResolvedValue(tabs)
+    mockTabGroupsGet.mockResolvedValue({
+      id: 10,
+      title: 'Research',
+      color: 'orange',
+      collapsed: true,
+      windowId: 1,
+    })
+    mockTabsGroup.mockResolvedValueOnce(71)
+
+    await createWindow(tabs as any)
+
+    expect(mockTabGroupsUpdate).toHaveBeenCalledWith(71, {
+      title: 'Research',
+      color: 'orange',
+      collapsed: true,
+    })
   })
 })

--- a/packages/extension/src/js/libs/index.tsx
+++ b/packages/extension/src/js/libs/index.tsx
@@ -34,11 +34,171 @@ export const moveTabs = async (tabs, windowId, from = 0) => {
   }
 }
 
+const getNoGroupId = () => browser.tabGroups?.TAB_GROUP_ID_NONE ?? -1
+
+const isNoGroupId = (groupId) => {
+  return groupId == null || groupId === getNoGroupId()
+}
+
+const getTabsInVisibleOrder = (tabs) => {
+  return tabs.slice().sort((a, b) => {
+    return (a.index ?? 0) - (b.index ?? 0)
+  })
+}
+
+const getBrowserTabGroup = async (groupId) => {
+  if (browser.tabGroups?.get) {
+    return browser.tabGroups.get(groupId)
+  }
+  if (typeof chrome !== 'undefined' && chrome.tabGroups?.get) {
+    return await new Promise((resolve) => {
+      chrome.tabGroups.get(groupId, (group) => {
+        resolve(group || null)
+      })
+    })
+  }
+  return null
+}
+
+const updateBrowserTabGroup = async (groupId, updateProperties) => {
+  if (browser.tabGroups?.update) {
+    return browser.tabGroups.update(groupId, updateProperties)
+  }
+  if (typeof chrome !== 'undefined' && chrome.tabGroups?.update) {
+    return await new Promise((resolve, reject) => {
+      chrome.tabGroups.update(groupId, updateProperties, (group) => {
+        const lastError = chrome.runtime?.lastError
+        if (lastError) {
+          reject(new Error(lastError.message))
+          return
+        }
+        resolve(group || null)
+      })
+    })
+  }
+  return null
+}
+
+const groupTabsInBrowser = async (tabIds) => {
+  if (!tabIds.length) {
+    return null
+  }
+  if (browser.tabs?.group) {
+    return browser.tabs.group({ tabIds })
+  }
+  if (typeof chrome !== 'undefined' && chrome.tabs?.group) {
+    return await new Promise((resolve, reject) => {
+      chrome.tabs.group({ tabIds }, (groupId) => {
+        const lastError = chrome.runtime?.lastError
+        if (lastError) {
+          reject(new Error(lastError.message))
+          return
+        }
+        resolve(groupId ?? null)
+      })
+    })
+  }
+  return null
+}
+
+const ungroupTabsInBrowser = async (tabIds) => {
+  if (!tabIds.length) {
+    return
+  }
+  if (browser.tabs?.ungroup) {
+    await browser.tabs.ungroup(tabIds)
+    return
+  }
+  if (typeof chrome !== 'undefined' && chrome.tabs?.ungroup) {
+    await new Promise((resolve, reject) => {
+      chrome.tabs.ungroup(tabIds, () => {
+        const lastError = chrome.runtime?.lastError
+        if (lastError) {
+          reject(new Error(lastError.message))
+          return
+        }
+        resolve(undefined)
+      })
+    })
+  }
+}
+
+const getSelectedGroupPlans = async (tabs) => {
+  const tabsByWindowId = new Map()
+  const windowIdsInOrder = []
+  tabs.forEach((tab) => {
+    if (!tabsByWindowId.has(tab.windowId)) {
+      tabsByWindowId.set(tab.windowId, [])
+      windowIdsInOrder.push(tab.windowId)
+    }
+    tabsByWindowId.get(tab.windowId).push(tab)
+  })
+
+  const wholeGroupPlans = []
+  const partialGroupTabIds = []
+
+  for (const windowId of windowIdsInOrder) {
+    const selectedTabs = tabsByWindowId.get(windowId) || []
+    const sourceTabs = getTabsInVisibleOrder(
+      await browser.tabs.query({ windowId }),
+    )
+    const selectedIds = new Set(selectedTabs.map((tab) => tab.id))
+    const seenGroupIds = new Set()
+
+    for (const tab of selectedTabs) {
+      if (isNoGroupId(tab.groupId) || seenGroupIds.has(tab.groupId)) {
+        continue
+      }
+      seenGroupIds.add(tab.groupId)
+      const selectedGroupTabs = selectedTabs.filter(
+        (candidate) => candidate.groupId === tab.groupId,
+      )
+      const sourceGroupTabs = sourceTabs.filter(
+        (candidate) => candidate.groupId === tab.groupId,
+      )
+      const isWholeGroup =
+        sourceGroupTabs.length > 0 &&
+        sourceGroupTabs.length === selectedGroupTabs.length &&
+        sourceGroupTabs.every((candidate) => selectedIds.has(candidate.id))
+      if (isWholeGroup) {
+        wholeGroupPlans.push({
+          groupId: tab.groupId,
+          tabIds: selectedGroupTabs.map((candidate) => candidate.id),
+          tabGroup: await getBrowserTabGroup(tab.groupId),
+        })
+      } else {
+        partialGroupTabIds.push(
+          ...selectedGroupTabs.map((candidate) => candidate.id),
+        )
+      }
+    }
+  }
+
+  return { wholeGroupPlans, partialGroupTabIds }
+}
+
 export const createWindow = async (tabs) => {
+  if (!tabs || tabs.length === 0) {
+    return
+  }
+  const { wholeGroupPlans, partialGroupTabIds } =
+    await getSelectedGroupPlans(tabs)
   const [firstTab, ...restTabs] = tabs
   const tabId = firstTab.id
   const win = await browser.windows.create({ tabId })
   await moveTabs(restTabs, win.id, -1)
+  await ungroupTabsInBrowser(partialGroupTabIds)
+  for (const plan of wholeGroupPlans) {
+    const newGroupId = await groupTabsInBrowser(plan.tabIds)
+    if (newGroupId == null || !plan.tabGroup) {
+      continue
+    }
+    await updateBrowserTabGroup(newGroupId, {
+      title: plan.tabGroup.title,
+      color: plan.tabGroup.color,
+      collapsed: plan.tabGroup.collapsed,
+    })
+  }
   await browser.windows.update(win.id, { focused: true })
 }
 

--- a/packages/extension/src/js/libs/index.tsx
+++ b/packages/extension/src/js/libs/index.tsx
@@ -123,6 +123,26 @@ const ungroupTabsInBrowser = async (tabIds) => {
   }
 }
 
+const hydrateTabsForGrouping = async (tabs) => {
+  return Promise.all(
+    tabs.map(async (tab) => {
+      const needsHydration =
+        typeof tab.windowId !== 'number' ||
+        typeof tab.index !== 'number' ||
+        typeof tab.groupId !== 'number'
+      if (!needsHydration) {
+        return tab
+      }
+      try {
+        const hydrated = await browser.tabs.get(tab.id)
+        return hydrated ? { ...tab, ...hydrated } : tab
+      } catch {
+        return tab
+      }
+    }),
+  )
+}
+
 const getSelectedGroupPlans = async (tabs) => {
   const tabsByWindowId = new Map()
   const windowIdsInOrder = []
@@ -181,8 +201,9 @@ export const createWindow = async (tabs) => {
   if (!tabs || tabs.length === 0) {
     return
   }
+  const hydratedTabs = await hydrateTabsForGrouping(tabs)
   const { wholeGroupPlans, partialGroupTabIds } =
-    await getSelectedGroupPlans(tabs)
+    await getSelectedGroupPlans(hydratedTabs)
   const [firstTab, ...restTabs] = tabs
   const tabId = firstTab.id
   const win = await browser.windows.create({ tabId })

--- a/packages/extension/src/js/stores/DragStore.tsx
+++ b/packages/extension/src/js/stores/DragStore.tsx
@@ -326,10 +326,12 @@ export default class DragStore {
       )
       const preserveWholeGroupOnBlankSpace =
         options.source === 'window-zone' && wholeGroupSelection
-      const wholeSelectedGroupIds =
-        options.source === 'window-zone'
-          ? this.getWholeSelectedGroupIds(sources)
-          : new Set<number>()
+      const wholeSelectedGroupIds = this.getWholeSelectedGroupIds(sources)
+      const wholeGroupOnlySelection =
+        sources.some((tab) => !this.isNoGroupId(tab.groupId)) &&
+        sources
+          .filter((tab) => !this.isNoGroupId(tab.groupId))
+          .every((tab) => wholeSelectedGroupIds.has(tab.groupId))
       const shouldPreserveWholeGroupsOnBlankSpace =
         options.source === 'window-zone' && wholeSelectedGroupIds.size > 0
       const sourceTabIds = sources.map((x) => x.id)
@@ -366,6 +368,7 @@ export default class DragStore {
       const canMoveGroup =
         hasTabGroupFlow &&
         this.canMoveGroups() &&
+        !hasTargetGroup &&
         !this.isNoGroupId(sourceGroupId) &&
         sourceGroupId !== targetGroupId &&
         wholeGroupSelection &&
@@ -375,8 +378,14 @@ export default class DragStore {
         this.canMutateGroups() &&
         hasTargetGroup &&
         sourceGroupId !== targetGroupId &&
-        !wholeGroupSelection &&
+        (options.source === 'group-header' || !wholeGroupOnlySelection) &&
         !options.forceUngroup
+      const shouldPreserveWholeGroupsOnTargetGroup =
+        hasTabGroupFlow &&
+        this.canMutateGroups() &&
+        hasTargetGroup &&
+        options.source === 'tab-row' &&
+        wholeGroupOnlySelection
       const shouldDetachFromSourceGroup =
         hasTabGroupFlow &&
         this.canMutateGroups() &&
@@ -396,7 +405,17 @@ export default class DragStore {
             detachableGroupedSourceTabIds,
           )
         }
-        if (shouldJoinTargetGroup) {
+        if (shouldPreserveWholeGroupsOnTargetGroup) {
+          await moveTabs(sources, windowId, index)
+          for (const groupId of wholeSelectedGroupIds) {
+            const preservedTabIds = sources
+              .filter((tab) => tab.groupId === groupId)
+              .map((tab) => tab.id)
+            if (preservedTabIds.length) {
+              await this.store.tabGroupStore.groupTabs(preservedTabIds, groupId)
+            }
+          }
+        } else if (shouldJoinTargetGroup) {
           const isUngroupedJoin =
             this.isNoGroupId(sourceGroupId) && groupedSourceTabIds.length === 0
           if (isUngroupedJoin) {

--- a/packages/extension/src/js/stores/DragStore.tsx
+++ b/packages/extension/src/js/stores/DragStore.tsx
@@ -328,10 +328,9 @@ export default class DragStore {
         options.source === 'window-zone' && wholeGroupSelection
       const wholeSelectedGroupIds = this.getWholeSelectedGroupIds(sources)
       const wholeGroupOnlySelection =
-        sources.some((tab) => !this.isNoGroupId(tab.groupId)) &&
-        sources
-          .filter((tab) => !this.isNoGroupId(tab.groupId))
-          .every((tab) => wholeSelectedGroupIds.has(tab.groupId))
+        sources.length > 0 &&
+        sources.every((tab) => !this.isNoGroupId(tab.groupId)) &&
+        sources.every((tab) => wholeSelectedGroupIds.has(tab.groupId))
       const shouldPreserveWholeGroupsOnBlankSpace =
         options.source === 'window-zone' && wholeSelectedGroupIds.size > 0
       const sourceTabIds = sources.map((x) => x.id)

--- a/packages/extension/src/js/stores/DragStore.tsx
+++ b/packages/extension/src/js/stores/DragStore.tsx
@@ -514,17 +514,17 @@ export default class DragStore {
               sources,
               wholeSelectedGroupIds,
             )
-            let currentIndex = index
-            for (const block of blocks) {
+            // Insert later blocks first so the final visible order matches the
+            // source window order when the browser applies the moves one by one.
+            for (const block of blocks.slice().reverse()) {
               if (block.kind === 'group') {
                 await this.store.tabGroupStore.moveGroup(block.groupId, {
                   windowId,
-                  index: currentIndex,
+                  index,
                 })
               } else {
-                await moveTabs(block.tabs, windowId, currentIndex)
+                await moveTabs(block.tabs, windowId, index)
               }
-              currentIndex += block.tabs.length
             }
           } else {
             await moveTabs(sources, windowId, index)

--- a/packages/extension/src/js/stores/DragStore.tsx
+++ b/packages/extension/src/js/stores/DragStore.tsx
@@ -330,6 +330,8 @@ export default class DragStore {
         options.source === 'window-zone'
           ? this.getWholeSelectedGroupIds(sources)
           : new Set<number>()
+      const shouldPreserveWholeGroupsOnBlankSpace =
+        options.source === 'window-zone' && wholeSelectedGroupIds.size > 0
       const sourceTabIds = sources.map((x) => x.id)
       // Blank-space drops detach only the selected tabs that are still partial
       // group fragments; fully selected groups stay intact.
@@ -439,18 +441,30 @@ export default class DragStore {
           }
         } else {
           await moveTabs(sources, windowId, index)
-          if (
-            hasTabGroupFlow &&
-            this.canMutateGroups() &&
-            !this.isNoGroupId(sourceGroupId) &&
-            wholeGroupSelection &&
-            sourceGroupId !== targetGroupId &&
-            !options.forceUngroup
-          ) {
-            await this.store.tabGroupStore.groupTabs(
-              sourceTabIds,
-              sourceGroupId,
-            )
+          if (hasTabGroupFlow && this.canMutateGroups()) {
+            if (shouldPreserveWholeGroupsOnBlankSpace) {
+              for (const groupId of wholeSelectedGroupIds) {
+                const preservedTabIds = sources
+                  .filter((tab) => tab.groupId === groupId)
+                  .map((tab) => tab.id)
+                if (preservedTabIds.length) {
+                  await this.store.tabGroupStore.groupTabs(
+                    preservedTabIds,
+                    groupId,
+                  )
+                }
+              }
+            } else if (
+              !this.isNoGroupId(sourceGroupId) &&
+              wholeGroupSelection &&
+              sourceGroupId !== targetGroupId &&
+              !options.forceUngroup
+            ) {
+              await this.store.tabGroupStore.groupTabs(
+                sourceTabIds,
+                sourceGroupId,
+              )
+            }
           }
         }
       }

--- a/packages/extension/src/js/stores/DragStore.tsx
+++ b/packages/extension/src/js/stores/DragStore.tsx
@@ -514,17 +514,17 @@ export default class DragStore {
               sources,
               wholeSelectedGroupIds,
             )
-            // Insert later blocks first so the final visible order matches the
-            // source window order when the browser applies the moves one by one.
-            for (const block of blocks.slice().reverse()) {
+            let currentIndex = index
+            for (const block of blocks) {
               if (block.kind === 'group') {
                 await this.store.tabGroupStore.moveGroup(block.groupId, {
                   windowId,
-                  index,
+                  index: currentIndex,
                 })
               } else {
-                await moveTabs(block.tabs, windowId, index)
+                await moveTabs(block.tabs, windowId, currentIndex)
               }
+              currentIndex += block.tabs.length
             }
           } else {
             await moveTabs(sources, windowId, index)

--- a/packages/extension/src/js/stores/DragStore.tsx
+++ b/packages/extension/src/js/stores/DragStore.tsx
@@ -20,6 +20,17 @@ type GroupBoundTab = {
   groupId: number | null | undefined
 }
 
+type BlankSpaceMoveBlock =
+  | {
+      kind: 'group'
+      groupId: number
+      tabs: Tab[]
+    }
+  | {
+      kind: 'tabs'
+      tabs: Tab[]
+    }
+
 export default class DragStore {
   store: Store
 
@@ -161,6 +172,41 @@ export default class DragStore {
         )
         .map(([groupId]) => groupId),
     )
+  }
+
+  getBlankSpaceMoveBlocks = (
+    tabs: Tab[],
+    wholeSelectedGroupIds: Set<number>,
+  ): BlankSpaceMoveBlock[] => {
+    const orderedTabs = tabs.slice().sort((a, b) => a.index - b.index)
+    const seenGroupIds = new Set<number>()
+    const blocks: BlankSpaceMoveBlock[] = []
+
+    for (const tab of orderedTabs) {
+      if (
+        !this.isNoGroupId(tab.groupId) &&
+        wholeSelectedGroupIds.has(tab.groupId)
+      ) {
+        if (seenGroupIds.has(tab.groupId)) {
+          continue
+        }
+        seenGroupIds.add(tab.groupId)
+        blocks.push({
+          kind: 'group',
+          groupId: tab.groupId,
+          tabs: orderedTabs.filter(
+            (candidate) => candidate.groupId === tab.groupId,
+          ),
+        })
+        continue
+      }
+      blocks.push({
+        kind: 'tabs',
+        tabs: [tab],
+      })
+    }
+
+    return blocks
   }
 
   getTargetIndex = (winTabs: Tab[], targetTab: Tab, before: boolean) => {
@@ -333,6 +379,11 @@ export default class DragStore {
         sources.every((tab) => wholeSelectedGroupIds.has(tab.groupId))
       const shouldPreserveWholeGroupsOnBlankSpace =
         options.source === 'window-zone' && wholeSelectedGroupIds.size > 0
+      const shouldMovePreservedWholeGroupsWithGroupApi =
+        shouldPreserveWholeGroupsOnBlankSpace &&
+        this.canMoveGroups() &&
+        sources.some((tab) => tab.windowId !== options.windowId) &&
+        sources.some((tab) => this.isNoGroupId(tab.groupId))
       const sourceTabIds = sources.map((x) => x.id)
       // Blank-space drops detach only the selected tabs that are still partial
       // group fragments; fully selected groups stay intact.
@@ -458,30 +509,49 @@ export default class DragStore {
             )
           }
         } else {
-          await moveTabs(sources, windowId, index)
-          if (hasTabGroupFlow && this.canMutateGroups()) {
-            if (shouldPreserveWholeGroupsOnBlankSpace) {
-              for (const groupId of wholeSelectedGroupIds) {
-                const preservedTabIds = sources
-                  .filter((tab) => tab.groupId === groupId)
-                  .map((tab) => tab.id)
-                if (preservedTabIds.length) {
-                  await this.store.tabGroupStore.groupTabs(
-                    preservedTabIds,
-                    groupId,
-                  )
-                }
+          if (shouldMovePreservedWholeGroupsWithGroupApi) {
+            const blocks = this.getBlankSpaceMoveBlocks(
+              sources,
+              wholeSelectedGroupIds,
+            )
+            let currentIndex = index
+            for (const block of blocks) {
+              if (block.kind === 'group') {
+                await this.store.tabGroupStore.moveGroup(block.groupId, {
+                  windowId,
+                  index: currentIndex,
+                })
+              } else {
+                await moveTabs(block.tabs, windowId, currentIndex)
               }
-            } else if (
-              !this.isNoGroupId(sourceGroupId) &&
-              wholeGroupSelection &&
-              sourceGroupId !== targetGroupId &&
-              !options.forceUngroup
-            ) {
-              await this.store.tabGroupStore.groupTabs(
-                sourceTabIds,
-                sourceGroupId,
-              )
+              currentIndex += block.tabs.length
+            }
+          } else {
+            await moveTabs(sources, windowId, index)
+            if (hasTabGroupFlow && this.canMutateGroups()) {
+              if (shouldPreserveWholeGroupsOnBlankSpace) {
+                for (const groupId of wholeSelectedGroupIds) {
+                  const preservedTabIds = sources
+                    .filter((tab) => tab.groupId === groupId)
+                    .map((tab) => tab.id)
+                  if (preservedTabIds.length) {
+                    await this.store.tabGroupStore.groupTabs(
+                      preservedTabIds,
+                      groupId,
+                    )
+                  }
+                }
+              } else if (
+                !this.isNoGroupId(sourceGroupId) &&
+                wholeGroupSelection &&
+                sourceGroupId !== targetGroupId &&
+                !options.forceUngroup
+              ) {
+                await this.store.tabGroupStore.groupTabs(
+                  sourceTabIds,
+                  sourceGroupId,
+                )
+              }
             }
           }
         }

--- a/packages/extension/src/js/stores/DragStore.tsx
+++ b/packages/extension/src/js/stores/DragStore.tsx
@@ -144,6 +144,25 @@ export default class DragStore {
     return groupTabs.every((x) => selectedIds.has(x.id))
   }
 
+  getWholeSelectedGroupIds = (tabs: Tab[]) => {
+    const groupedTabsByGroupId = new Map<number, Tab[]>()
+    tabs.forEach((tab) => {
+      if (this.isNoGroupId(tab.groupId)) {
+        return
+      }
+      const groupTabs = groupedTabsByGroupId.get(tab.groupId) ?? []
+      groupTabs.push(tab)
+      groupedTabsByGroupId.set(tab.groupId, groupTabs)
+    })
+    return new Set(
+      Array.from(groupedTabsByGroupId.entries())
+        .filter(([groupId, groupTabs]) =>
+          this.isWholeGroupSelection(groupId, groupTabs),
+        )
+        .map(([groupId]) => groupId),
+    )
+  }
+
   getTargetIndex = (winTabs: Tab[], targetTab: Tab, before: boolean) => {
     const targetGroupId = targetTab.groupId
     if (
@@ -305,10 +324,22 @@ export default class DragStore {
         sourceGroupId,
         sources,
       )
+      const preserveWholeGroupOnBlankSpace =
+        options.source === 'window-zone' && wholeGroupSelection
+      const wholeSelectedGroupIds =
+        options.source === 'window-zone'
+          ? this.getWholeSelectedGroupIds(sources)
+          : new Set<number>()
       const sourceTabIds = sources.map((x) => x.id)
-      const groupedSourceTabIds = sources
-        .filter((x) => !this.isNoGroupId(x.groupId))
-        .map((x) => x.id)
+      // Blank-space drops detach only the selected tabs that are still partial
+      // group fragments; fully selected groups stay intact.
+      const groupedSourceTabs = sources.filter(
+        (x) => !this.isNoGroupId(x.groupId),
+      )
+      const groupedSourceTabIds = groupedSourceTabs.map((x) => x.id)
+      const detachableGroupedSourceTabIds = groupedSourceTabs
+        .filter((tab) => !wholeSelectedGroupIds.has(tab.groupId))
+        .map((tab) => tab.id)
       const { windowId } = options
       const win = getTargetWindow(windowId)
       const targetGroupId = options.targetGroupId ?? this.getNoGroupId()
@@ -336,7 +367,7 @@ export default class DragStore {
         !this.isNoGroupId(sourceGroupId) &&
         sourceGroupId !== targetGroupId &&
         wholeGroupSelection &&
-        !options.forceUngroup
+        (!options.forceUngroup || preserveWholeGroupOnBlankSpace)
       const shouldJoinTargetGroup =
         hasTabGroupFlow &&
         this.canMutateGroups() &&
@@ -347,8 +378,7 @@ export default class DragStore {
       const shouldDetachFromSourceGroup =
         hasTabGroupFlow &&
         this.canMutateGroups() &&
-        !wholeGroupSelection &&
-        groupedSourceTabIds.length > 0 &&
+        detachableGroupedSourceTabIds.length > 0 &&
         (!!options.forceUngroup || !hasTargetGroup)
       let movedByGroupApi = false
       if (canMoveGroup) {
@@ -360,7 +390,9 @@ export default class DragStore {
       }
       if (!movedByGroupApi) {
         if (shouldDetachFromSourceGroup) {
-          await this.store.tabGroupStore.ungroupTabs(groupedSourceTabIds)
+          await this.store.tabGroupStore.ungroupTabs(
+            detachableGroupedSourceTabIds,
+          )
         }
         if (shouldJoinTargetGroup) {
           const isUngroupedJoin =

--- a/packages/extension/src/js/stores/DragStore.tsx
+++ b/packages/extension/src/js/stores/DragStore.tsx
@@ -178,7 +178,7 @@ export default class DragStore {
     tabs: Tab[],
     wholeSelectedGroupIds: Set<number>,
   ): BlankSpaceMoveBlock[] => {
-    const orderedTabs = tabs.slice().sort((a, b) => a.index - b.index)
+    const orderedTabs = tabs.slice()
     const seenGroupIds = new Set<number>()
     const blocks: BlankSpaceMoveBlock[] = []
 
@@ -397,10 +397,19 @@ export default class DragStore {
       const { windowId } = options
       const win = getTargetWindow(windowId)
       const targetGroupId = options.targetGroupId ?? this.getNoGroupId()
+      const targetTab =
+        typeof options.targetTabId === 'number'
+          ? win.tabs.find((tab) => tab.id === options.targetTabId)
+          : null
       const targetIndex = Math.max(
         0,
         Math.min(
-          this.getResolvedTargetIndex(win.tabs, options),
+          options.source === 'tab-row' &&
+            wholeGroupOnlySelection &&
+            targetTab &&
+            !this.isNoGroupId(targetGroupId)
+            ? this.getTargetIndex(win.tabs, targetTab, !!options.before)
+            : this.getResolvedTargetIndex(win.tabs, options),
           win.tabs.length,
         ),
       )

--- a/packages/extension/src/js/stores/__tests__/DragStore.grouping.test.tsx
+++ b/packages/extension/src/js/stores/__tests__/DragStore.grouping.test.tsx
@@ -502,6 +502,57 @@ describe('DragStore with tab groups', () => {
     expect(groupTabs).not.toHaveBeenCalledWith(expect.any(Array), 20)
   })
 
+  it('grouped tab-row drop resolves whole-group-only selections against the target group boundary', async () => {
+    process.env.TARGET_BROWSER = 'chrome'
+    const selection = new Map()
+    const wholeGroupTab1 = { id: 1, groupId: 10, windowId: 2, index: 0 }
+    const wholeGroupTab2 = { id: 2, groupId: 10, windowId: 2, index: 1 }
+    const targetTab1 = { id: 3, groupId: 20, windowId: 1, index: 0 }
+    const targetTab2 = { id: 4, groupId: 20, windowId: 1, index: 1 }
+    const targetTab3 = { id: 5, groupId: 20, windowId: 1, index: 2 }
+    const moveTabs = jest.fn(() => Promise.resolve())
+    const moveGroup = jest.fn(() => Promise.resolve())
+    const groupTabs = jest.fn(() => Promise.resolve())
+    const tabStore = setupTabStore(selection)
+    const dragStore = new DragStore({
+      tabStore,
+      tabGroupStore: {
+        getTabsForGroup: jest.fn((groupId: number) => {
+          if (groupId === 10) {
+            return [wholeGroupTab1, wholeGroupTab2]
+          }
+          return [targetTab1, targetTab2, targetTab3]
+        }),
+        moveGroup,
+        groupTabs,
+        getNoGroupId: () => -1,
+        hasTabGroupsApi: () => true,
+        canMutateGroups: () => true,
+        canMoveGroups: () => true,
+      },
+      windowStore: {
+        suspend: jest.fn(),
+        resume: jest.fn(),
+        markLayoutDirtyIfNeeded: jest.fn(),
+        moveTabs,
+        getTargetWindow: jest.fn(() => ({
+          tabs: [targetTab1, targetTab2, targetTab3],
+        })),
+      },
+    } as any)
+
+    dragStore.dragStartGroup(10)
+    await dragStore.drop(targetTab3 as any, true)
+
+    expect(moveGroup).not.toHaveBeenCalled()
+    expect(moveTabs).toHaveBeenCalledWith(
+      [wholeGroupTab1, wholeGroupTab2],
+      1,
+      0,
+    )
+    expect(groupTabs).toHaveBeenCalledWith([1, 2], 10)
+  })
+
   it('grouped tab-row drop merges loose or partial-group selections into the target group', async () => {
     process.env.TARGET_BROWSER = 'chrome'
     const selection = new Map()
@@ -944,6 +995,81 @@ describe('DragStore with tab groups', () => {
     )
     expect(groupTabs).not.toHaveBeenCalled()
     expect(ungroupTabs).not.toHaveBeenCalled()
+  })
+
+  it('window-zone drop preserves cross-window block order for whole groups and loose tabs', async () => {
+    process.env.TARGET_BROWSER = 'chrome'
+    const selection = new Map()
+    const window1LooseTab = { id: 1, groupId: -1, windowId: 1, index: 5 }
+    const window2GroupTab1 = { id: 2, groupId: 10, windowId: 2, index: 0 }
+    const window2GroupTab2 = { id: 3, groupId: 10, windowId: 2, index: 1 }
+    const moveTabs = jest.fn(() => Promise.resolve())
+    const moveGroup = jest.fn(() => Promise.resolve({ id: 10 }))
+    const groupTabs = jest.fn(() => Promise.resolve())
+    const ungroupTabs = jest.fn(() => Promise.resolve())
+    const tabStore = {
+      selection,
+      unselectAll: jest.fn(() => selection.clear()),
+      get sources() {
+        return Array.from(selection.values()).sort((a: any, b: any) => {
+          if (a.windowId === b.windowId) {
+            return a.index - b.index
+          }
+          return a.windowId - b.windowId
+        })
+      },
+    }
+    const dragStore = new DragStore({
+      tabStore,
+      tabGroupStore: {
+        getTabsForGroup: jest.fn((groupId: number) => {
+          if (groupId === 10) {
+            return [window2GroupTab1, window2GroupTab2]
+          }
+          return []
+        }),
+        moveGroup,
+        groupTabs,
+        ungroupTabs,
+        getNoGroupId: () => -1,
+        hasTabGroupsApi: () => true,
+        canMutateGroups: () => true,
+        canMoveGroups: () => true,
+      },
+      windowStore: {
+        suspend: jest.fn(),
+        resume: jest.fn(),
+        markLayoutDirtyIfNeeded: jest.fn(),
+        moveTabs,
+        getTargetWindow: jest.fn(() => ({
+          tabs: [],
+        })),
+      },
+    } as any)
+
+    dragStore.dragStartTab({ ...window1LooseTab, unhover: jest.fn() } as any)
+    selection.set(window2GroupTab1.id, window2GroupTab1 as any)
+    selection.set(window2GroupTab2.id, window2GroupTab2 as any)
+
+    await dragStore.dropAt({
+      windowId: 3,
+      index: 0,
+      forceUngroup: true,
+      source: 'window-zone',
+    })
+
+    expect(moveTabs).toHaveBeenNthCalledWith(
+      1,
+      [expect.objectContaining({ id: 1, windowId: 1 })],
+      3,
+      0,
+    )
+    expect(moveGroup).toHaveBeenNthCalledWith(1, 10, {
+      windowId: 3,
+      index: 1,
+    })
+    expect(ungroupTabs).not.toHaveBeenCalled()
+    expect(groupTabs).not.toHaveBeenCalled()
   })
 
   it('window-zone drop preserves a whole group without moveGroup support', async () => {

--- a/packages/extension/src/js/stores/__tests__/DragStore.grouping.test.tsx
+++ b/packages/extension/src/js/stores/__tests__/DragStore.grouping.test.tsx
@@ -171,6 +171,276 @@ describe('DragStore with tab groups', () => {
     expect(moveGroup).not.toHaveBeenCalled()
   })
 
+  it('group header before-zone keeps a whole selected group separate', async () => {
+    process.env.TARGET_BROWSER = 'chrome'
+    const selection = new Map()
+    const sourceTab1 = { id: 1, groupId: 10, windowId: 1, index: 0 }
+    const sourceTab2 = { id: 2, groupId: 10, windowId: 1, index: 1 }
+    const targetTab1 = { id: 3, groupId: 20, windowId: 1, index: 2 }
+    const targetTab2 = { id: 4, groupId: 20, windowId: 1, index: 3 }
+    const moveTabs = jest.fn(() => Promise.resolve())
+    const moveGroup = jest.fn(() => Promise.resolve())
+    const groupTabs = jest.fn(() => Promise.resolve())
+    const tabStore = setupTabStore(selection)
+    const dragStore = new DragStore({
+      tabStore,
+      tabGroupStore: {
+        getTabsForGroup: jest.fn((groupId: number) => {
+          if (groupId === 10) {
+            return [sourceTab1, sourceTab2]
+          }
+          return [targetTab1, targetTab2]
+        }),
+        moveGroup,
+        groupTabs,
+        getNoGroupId: () => -1,
+        hasTabGroupsApi: () => true,
+        canMutateGroups: () => true,
+        canMoveGroups: () => true,
+      },
+      windowStore: {
+        suspend: jest.fn(),
+        resume: jest.fn(),
+        markLayoutDirtyIfNeeded: jest.fn(),
+        moveTabs,
+        getTargetWindow: jest.fn(() => ({
+          tabs: [sourceTab1, sourceTab2, targetTab1, targetTab2],
+        })),
+      },
+    } as any)
+    dragStore.getWindowTabsFromBrowser = jest
+      .fn()
+      .mockResolvedValue([sourceTab1, sourceTab2, targetTab1, targetTab2])
+
+    dragStore.dragStartGroup(10)
+    await dragStore.dropAt({
+      windowId: 1,
+      index: 2,
+      source: 'group-header',
+    })
+
+    expect(moveGroup).toHaveBeenCalledWith(10, {
+      windowId: 1,
+      index: 0,
+    })
+    expect(groupTabs).not.toHaveBeenCalled()
+    expect(moveTabs).not.toHaveBeenCalled()
+  })
+
+  it('group header center merges the entire selected group into the target group', async () => {
+    process.env.TARGET_BROWSER = 'chrome'
+    const selection = new Map()
+    const sourceTab1 = { id: 1, groupId: 10, windowId: 1, index: 0 }
+    const sourceTab2 = { id: 2, groupId: 10, windowId: 1, index: 1 }
+    const targetTab1 = { id: 3, groupId: 20, windowId: 1, index: 2 }
+    const targetTab2 = { id: 4, groupId: 20, windowId: 1, index: 3 }
+    const moveTabs = jest.fn(() => Promise.resolve())
+    const moveGroup = jest.fn(() => Promise.resolve())
+    const groupTabs = jest.fn(() => Promise.resolve())
+    const tabStore = setupTabStore(selection)
+    const dragStore = new DragStore({
+      tabStore,
+      tabGroupStore: {
+        getTabsForGroup: jest.fn((groupId: number) => {
+          if (groupId === 10) {
+            return [sourceTab1, sourceTab2]
+          }
+          return [targetTab1, targetTab2]
+        }),
+        moveGroup,
+        groupTabs,
+        getNoGroupId: () => -1,
+        hasTabGroupsApi: () => true,
+        canMutateGroups: () => true,
+        canMoveGroups: () => true,
+      },
+      windowStore: {
+        suspend: jest.fn(),
+        resume: jest.fn(),
+        markLayoutDirtyIfNeeded: jest.fn(),
+        moveTabs,
+        getTargetWindow: jest.fn(() => ({
+          tabs: [sourceTab1, sourceTab2, targetTab1, targetTab2],
+        })),
+      },
+    } as any)
+    dragStore.getWindowTabsFromBrowser = jest
+      .fn()
+      .mockResolvedValue([sourceTab1, sourceTab2, targetTab1, targetTab2])
+
+    dragStore.dragStartGroup(10)
+    await dragStore.dropAt({
+      windowId: 1,
+      index: 2,
+      targetGroupId: 20,
+      before: true,
+      source: 'group-header',
+    })
+
+    expect(moveGroup).not.toHaveBeenCalled()
+    expect(groupTabs).toHaveBeenCalledWith([1, 2, 3, 4], 20)
+    expect(moveTabs).not.toHaveBeenCalled()
+  })
+
+  it('grouped tab-row drop keeps whole-group-only selections separate', async () => {
+    process.env.TARGET_BROWSER = 'chrome'
+    const selection = new Map()
+    const wholeGroupTab1 = { id: 1, groupId: 10, windowId: 1, index: 0 }
+    const wholeGroupTab2 = { id: 2, groupId: 10, windowId: 1, index: 1 }
+    const otherGroupTab1 = { id: 3, groupId: 30, windowId: 1, index: 2 }
+    const otherGroupTab2 = { id: 4, groupId: 30, windowId: 1, index: 3 }
+    const targetTab1 = { id: 5, groupId: 20, windowId: 1, index: 4 }
+    const targetTab2 = { id: 6, groupId: 20, windowId: 1, index: 5 }
+    const moveTabs = jest.fn(() => Promise.resolve())
+    const moveGroup = jest.fn(() => Promise.resolve())
+    const groupTabs = jest.fn(() => Promise.resolve())
+    const tabStore = setupTabStore(selection)
+    const dragStore = new DragStore({
+      tabStore,
+      tabGroupStore: {
+        getTabsForGroup: jest.fn((groupId: number) => {
+          if (groupId === 10) {
+            return [wholeGroupTab1, wholeGroupTab2]
+          }
+          if (groupId === 30) {
+            return [otherGroupTab1, otherGroupTab2]
+          }
+          return [targetTab1, targetTab2]
+        }),
+        moveGroup,
+        groupTabs,
+        getNoGroupId: () => -1,
+        hasTabGroupsApi: () => true,
+        canMutateGroups: () => true,
+        canMoveGroups: () => true,
+      },
+      windowStore: {
+        suspend: jest.fn(),
+        resume: jest.fn(),
+        markLayoutDirtyIfNeeded: jest.fn(),
+        moveTabs,
+        getTargetWindow: jest.fn(() => ({
+          tabs: [
+            wholeGroupTab1,
+            wholeGroupTab2,
+            otherGroupTab1,
+            otherGroupTab2,
+            targetTab1,
+            targetTab2,
+          ],
+        })),
+      },
+    } as any)
+    dragStore.getWindowTabsFromBrowser = jest
+      .fn()
+      .mockResolvedValue([
+        wholeGroupTab1,
+        wholeGroupTab2,
+        otherGroupTab1,
+        otherGroupTab2,
+        targetTab1,
+        targetTab2,
+      ])
+    dragStore.dragStartTab({ ...wholeGroupTab1, unhover: jest.fn() } as any)
+    selection.set(wholeGroupTab2.id, wholeGroupTab2 as any)
+    selection.set(otherGroupTab1.id, otherGroupTab1 as any)
+    selection.set(otherGroupTab2.id, otherGroupTab2 as any)
+
+    await dragStore.dropAt({
+      windowId: 1,
+      index: 4,
+      targetGroupId: 20,
+      before: true,
+      source: 'tab-row',
+    })
+
+    expect(moveGroup).not.toHaveBeenCalled()
+    expect(groupTabs).toHaveBeenCalledWith([1, 2], 10)
+    expect(groupTabs).toHaveBeenCalledWith([3, 4], 30)
+    expect(groupTabs).not.toHaveBeenCalledWith(expect.any(Array), 20)
+  })
+
+  it('grouped tab-row drop merges loose or partial-group selections into the target group', async () => {
+    process.env.TARGET_BROWSER = 'chrome'
+    const selection = new Map()
+    const looseTab = { id: 1, groupId: -1, windowId: 1, index: 0 }
+    const partialGroupTab1 = { id: 2, groupId: 10, windowId: 1, index: 1 }
+    const partialGroupTab2 = { id: 3, groupId: 10, windowId: 1, index: 2 }
+    const targetTab1 = { id: 4, groupId: 20, windowId: 1, index: 3 }
+    const targetTab2 = { id: 5, groupId: 20, windowId: 1, index: 4 }
+    const moveTabs = jest.fn(() => Promise.resolve())
+    const moveGroup = jest.fn(() => Promise.resolve())
+    const groupTabs = jest.fn(() => Promise.resolve())
+    const tabStore = setupTabStore(selection)
+    const dragStore = new DragStore({
+      tabStore,
+      tabGroupStore: {
+        getTabsForGroup: jest.fn((groupId: number) => {
+          if (groupId === 10) {
+            return [
+              partialGroupTab1,
+              partialGroupTab2,
+              {
+                id: 6,
+                groupId: 10,
+                windowId: 1,
+                index: 5,
+              },
+            ]
+          }
+          return [targetTab1, targetTab2]
+        }),
+        moveGroup,
+        groupTabs,
+        getNoGroupId: () => -1,
+        hasTabGroupsApi: () => true,
+        canMutateGroups: () => true,
+        canMoveGroups: () => true,
+      },
+      windowStore: {
+        suspend: jest.fn(),
+        resume: jest.fn(),
+        markLayoutDirtyIfNeeded: jest.fn(),
+        moveTabs,
+        getTargetWindow: jest.fn(() => ({
+          tabs: [
+            looseTab,
+            partialGroupTab1,
+            partialGroupTab2,
+            targetTab1,
+            targetTab2,
+          ],
+        })),
+      },
+    } as any)
+    dragStore.getWindowTabsFromBrowser = jest
+      .fn()
+      .mockResolvedValue([
+        looseTab,
+        partialGroupTab1,
+        partialGroupTab2,
+        targetTab1,
+        targetTab2,
+      ])
+    dragStore.dragStartTab({ ...looseTab, unhover: jest.fn() } as any)
+    selection.set(partialGroupTab1.id, partialGroupTab1 as any)
+    selection.set(partialGroupTab2.id, partialGroupTab2 as any)
+
+    await dragStore.dropAt({
+      windowId: 1,
+      index: 3,
+      targetGroupId: 20,
+      before: true,
+      source: 'tab-row',
+    })
+
+    expect(moveGroup).not.toHaveBeenCalled()
+    expect(groupTabs).toHaveBeenCalledWith(
+      expect.arrayContaining([1, 2, 3]),
+      20,
+    )
+  })
+
   it('should apply grouped drop behavior in firefox when tab group capabilities exist', async () => {
     process.env.TARGET_BROWSER = 'firefox'
     const selection = new Map()
@@ -697,7 +967,7 @@ describe('DragStore with tab groups', () => {
     expect(moveTabs).not.toHaveBeenCalled()
   })
 
-  it('full-group selection should use moveGroup fast path', async () => {
+  it('full-group tab-row selection should preserve the selected group block', async () => {
     process.env.TARGET_BROWSER = 'chrome'
     const selection = new Map()
     const tab1 = { id: 1, groupId: -1, windowId: 1, index: 0 }
@@ -742,15 +1012,12 @@ describe('DragStore with tab groups', () => {
     dragStore.dragStartGroup(10)
     await dragStore.drop(tab4 as any, true)
 
-    expect(moveGroup).toHaveBeenCalledWith(10, {
-      windowId: 1,
-      index: 1,
-    })
-    expect(moveTabs).not.toHaveBeenCalled()
-    expect(groupTabs).not.toHaveBeenCalled()
+    expect(moveGroup).not.toHaveBeenCalled()
+    expect(moveTabs).toHaveBeenCalledWith([tab2, tab3], 1, 1)
+    expect(groupTabs).toHaveBeenCalledWith([2, 3], 10)
   })
 
-  it('full-group selection should not fallback when moveGroup resolves null', async () => {
+  it('full-group tab-row selection preserves the block even without moveGroup support', async () => {
     process.env.TARGET_BROWSER = 'chrome'
     const selection = new Map()
     const tab1 = { id: 1, groupId: -1, windowId: 1, index: 0 }
@@ -791,11 +1058,8 @@ describe('DragStore with tab groups', () => {
     dragStore.dragStartGroup(10)
     await dragStore.drop(tab4 as any, true)
 
-    expect(moveGroup).toHaveBeenCalledWith(10, {
-      windowId: 1,
-      index: 1,
-    })
-    expect(moveTabs).not.toHaveBeenCalled()
-    expect(groupTabs).not.toHaveBeenCalled()
+    expect(moveGroup).not.toHaveBeenCalled()
+    expect(moveTabs).toHaveBeenCalledWith([tab2, tab3], 1, 1)
+    expect(groupTabs).toHaveBeenCalledWith([2, 3], 10)
   })
 })

--- a/packages/extension/src/js/stores/__tests__/DragStore.grouping.test.tsx
+++ b/packages/extension/src/js/stores/__tests__/DragStore.grouping.test.tsx
@@ -282,6 +282,91 @@ describe('DragStore with tab groups', () => {
     expect(moveTabs).not.toHaveBeenCalled()
   })
 
+  it('group header center merges the entire mixed selection into the target group', async () => {
+    process.env.TARGET_BROWSER = 'chrome'
+    const selection = new Map()
+    const looseTab = { id: 1, groupId: -1, windowId: 1, index: 0 }
+    const sourceGroupTab1 = { id: 2, groupId: 10, windowId: 1, index: 1 }
+    const sourceGroupTab2 = { id: 3, groupId: 10, windowId: 1, index: 2 }
+    const otherGroupTab1 = { id: 4, groupId: 30, windowId: 1, index: 3 }
+    const otherGroupTab2 = { id: 5, groupId: 30, windowId: 1, index: 4 }
+    const targetTab1 = { id: 6, groupId: 20, windowId: 1, index: 5 }
+    const targetTab2 = { id: 7, groupId: 20, windowId: 1, index: 6 }
+    const moveTabs = jest.fn(() => Promise.resolve())
+    const moveGroup = jest.fn(() => Promise.resolve())
+    const groupTabs = jest.fn(() => Promise.resolve())
+    const tabStore = setupTabStore(selection)
+    const dragStore = new DragStore({
+      tabStore,
+      tabGroupStore: {
+        getTabsForGroup: jest.fn((groupId: number) => {
+          if (groupId === 10) {
+            return [sourceGroupTab1, sourceGroupTab2]
+          }
+          if (groupId === 30) {
+            return [otherGroupTab1, otherGroupTab2]
+          }
+          return [targetTab1, targetTab2]
+        }),
+        moveGroup,
+        groupTabs,
+        getNoGroupId: () => -1,
+        hasTabGroupsApi: () => true,
+        canMutateGroups: () => true,
+        canMoveGroups: () => true,
+      },
+      windowStore: {
+        suspend: jest.fn(),
+        resume: jest.fn(),
+        markLayoutDirtyIfNeeded: jest.fn(),
+        moveTabs,
+        getTargetWindow: jest.fn(() => ({
+          tabs: [
+            looseTab,
+            sourceGroupTab1,
+            sourceGroupTab2,
+            otherGroupTab1,
+            otherGroupTab2,
+            targetTab1,
+            targetTab2,
+          ],
+        })),
+      },
+    } as any)
+    dragStore.getWindowTabsFromBrowser = jest
+      .fn()
+      .mockResolvedValue([
+        looseTab,
+        sourceGroupTab1,
+        sourceGroupTab2,
+        otherGroupTab1,
+        otherGroupTab2,
+        targetTab1,
+        targetTab2,
+      ])
+
+    dragStore.dragStartTab({ ...looseTab, unhover: jest.fn() } as any)
+    selection.set(sourceGroupTab1.id, sourceGroupTab1 as any)
+    selection.set(sourceGroupTab2.id, sourceGroupTab2 as any)
+    selection.set(otherGroupTab1.id, otherGroupTab1 as any)
+    selection.set(otherGroupTab2.id, otherGroupTab2 as any)
+
+    await dragStore.dropAt({
+      windowId: 1,
+      index: 5,
+      targetGroupId: 20,
+      before: true,
+      source: 'tab-row',
+    })
+
+    expect(moveGroup).not.toHaveBeenCalled()
+    expect(groupTabs).toHaveBeenCalledWith(
+      expect.arrayContaining([1, 2, 3, 4, 5, 6, 7]),
+      20,
+    )
+    expect(moveTabs).not.toHaveBeenCalled()
+  })
+
   it('grouped tab-row drop keeps whole-group-only selections separate', async () => {
     process.env.TARGET_BROWSER = 'chrome'
     const selection = new Map()

--- a/packages/extension/src/js/stores/__tests__/DragStore.grouping.test.tsx
+++ b/packages/extension/src/js/stores/__tests__/DragStore.grouping.test.tsx
@@ -934,11 +934,11 @@ describe('DragStore with tab groups', () => {
       source: 'window-zone',
     })
 
+    expect(moveTabs).toHaveBeenNthCalledWith(1, [looseTab], 1, 0)
     expect(moveGroup).toHaveBeenCalledWith(10, {
       windowId: 1,
       index: 0,
     })
-    expect(moveTabs).toHaveBeenCalledWith([looseTab], 1, 2)
     expect(groupTabs).not.toHaveBeenCalled()
     expect(ungroupTabs).not.toHaveBeenCalled()
   })

--- a/packages/extension/src/js/stores/__tests__/DragStore.grouping.test.tsx
+++ b/packages/extension/src/js/stores/__tests__/DragStore.grouping.test.tsx
@@ -934,11 +934,14 @@ describe('DragStore with tab groups', () => {
       source: 'window-zone',
     })
 
-    expect(moveTabs).toHaveBeenNthCalledWith(1, [looseTab], 1, 0)
     expect(moveGroup).toHaveBeenCalledWith(10, {
       windowId: 1,
       index: 0,
     })
+    expect(moveTabs).toHaveBeenCalledWith([looseTab], 1, 2)
+    expect(moveGroup.mock.invocationCallOrder[0]).toBeLessThan(
+      moveTabs.mock.invocationCallOrder[0],
+    )
     expect(groupTabs).not.toHaveBeenCalled()
     expect(ungroupTabs).not.toHaveBeenCalled()
   })

--- a/packages/extension/src/js/stores/__tests__/DragStore.grouping.test.tsx
+++ b/packages/extension/src/js/stores/__tests__/DragStore.grouping.test.tsx
@@ -282,6 +282,63 @@ describe('DragStore with tab groups', () => {
     expect(moveTabs).not.toHaveBeenCalled()
   })
 
+  it('manually selected whole group merges into the target group from a tab-row drag', async () => {
+    process.env.TARGET_BROWSER = 'chrome'
+    const selection = new Map()
+    const sourceTab1 = { id: 1, groupId: 10, windowId: 1, index: 0 }
+    const sourceTab2 = { id: 2, groupId: 10, windowId: 1, index: 1 }
+    const targetTab1 = { id: 3, groupId: 20, windowId: 1, index: 2 }
+    const targetTab2 = { id: 4, groupId: 20, windowId: 1, index: 3 }
+    const moveTabs = jest.fn(() => Promise.resolve())
+    const moveGroup = jest.fn(() => Promise.resolve())
+    const groupTabs = jest.fn(() => Promise.resolve())
+    const tabStore = setupTabStore(selection)
+    const dragStore = new DragStore({
+      tabStore,
+      tabGroupStore: {
+        getTabsForGroup: jest.fn((groupId: number) => {
+          if (groupId === 10) {
+            return [sourceTab1, sourceTab2]
+          }
+          return [targetTab1, targetTab2]
+        }),
+        moveGroup,
+        groupTabs,
+        getNoGroupId: () => -1,
+        hasTabGroupsApi: () => true,
+        canMutateGroups: () => true,
+        canMoveGroups: () => true,
+      },
+      windowStore: {
+        suspend: jest.fn(),
+        resume: jest.fn(),
+        markLayoutDirtyIfNeeded: jest.fn(),
+        moveTabs,
+        getTargetWindow: jest.fn(() => ({
+          tabs: [sourceTab1, sourceTab2, targetTab1, targetTab2],
+        })),
+      },
+    } as any)
+    dragStore.getWindowTabsFromBrowser = jest
+      .fn()
+      .mockResolvedValue([sourceTab1, sourceTab2, targetTab1, targetTab2])
+
+    dragStore.dragStartTab({ ...sourceTab1, unhover: jest.fn() } as any)
+    selection.set(sourceTab2.id, sourceTab2 as any)
+
+    await dragStore.dropAt({
+      windowId: 1,
+      index: 2,
+      targetGroupId: 20,
+      before: true,
+      source: 'group-header',
+    })
+
+    expect(moveGroup).not.toHaveBeenCalled()
+    expect(groupTabs).toHaveBeenCalledWith([1, 2, 3, 4], 20)
+    expect(moveTabs).not.toHaveBeenCalled()
+  })
+
   it('group header center merges the entire mixed selection into the target group', async () => {
     process.env.TARGET_BROWSER = 'chrome'
     const selection = new Map()

--- a/packages/extension/src/js/stores/__tests__/DragStore.grouping.test.tsx
+++ b/packages/extension/src/js/stores/__tests__/DragStore.grouping.test.tsx
@@ -12,6 +12,34 @@ const setupTabStore = (selection: Map<number, any>) => {
   }
 }
 
+const setupDragStore = ({
+  selection,
+  tabGroupStore,
+  targetTabs,
+  moveTabs = jest.fn(() => Promise.resolve()),
+}: {
+  selection: Map<number, any>
+  tabGroupStore: Record<string, any>
+  targetTabs: any[]
+  moveTabs?: jest.Mock
+}) => {
+  const tabStore = setupTabStore(selection)
+  const windowStore = {
+    suspend: jest.fn(),
+    resume: jest.fn(),
+    markLayoutDirtyIfNeeded: jest.fn(),
+    moveTabs,
+    getTargetWindow: jest.fn(() => ({
+      tabs: targetTabs,
+    })),
+  }
+  return new DragStore({
+    tabStore,
+    tabGroupStore,
+    windowStore,
+  } as any)
+}
+
 describe('DragStore with tab groups', () => {
   const originalTargetBrowser = process.env.TARGET_BROWSER
 
@@ -253,6 +281,203 @@ describe('DragStore with tab groups', () => {
       0,
     )
     expect(groupTabs).not.toHaveBeenCalled()
+  })
+
+  it('window-zone drop preserves a whole selected group when moving to another window', async () => {
+    process.env.TARGET_BROWSER = 'chrome'
+    const selection = new Map()
+    const sourceTab1 = { id: 1, groupId: 10, windowId: 2, index: 0 }
+    const sourceTab2 = { id: 2, groupId: 10, windowId: 2, index: 1 }
+    const targetTab = { id: 3, groupId: -1, windowId: 1, index: 0 }
+    const moveTabs = jest.fn(() => Promise.resolve())
+    const moveGroup = jest.fn(() => Promise.resolve())
+    const groupTabs = jest.fn(() => Promise.resolve())
+    const ungroupTabs = jest.fn(() => Promise.resolve())
+    const dragStore = setupDragStore({
+      selection,
+      targetTabs: [targetTab],
+      moveTabs,
+      tabGroupStore: {
+        getTabsForGroup: jest.fn(() => [sourceTab1, sourceTab2]),
+        moveGroup,
+        groupTabs,
+        ungroupTabs,
+        getNoGroupId: () => -1,
+        hasTabGroupsApi: () => true,
+        canMutateGroups: () => true,
+        canMoveGroups: () => true,
+      },
+    })
+    dragStore.dragStartTab({ ...sourceTab1, unhover: jest.fn() } as any)
+    selection.set(sourceTab2.id, sourceTab2 as any)
+
+    await dragStore.dropAt({
+      windowId: 1,
+      index: 0,
+      forceUngroup: true,
+      source: 'window-zone',
+    })
+
+    expect(moveGroup).toHaveBeenCalledWith(10, {
+      windowId: 1,
+      index: 0,
+    })
+    expect(ungroupTabs).not.toHaveBeenCalled()
+    expect(groupTabs).not.toHaveBeenCalled()
+    expect(moveTabs).not.toHaveBeenCalled()
+  })
+
+  it('window-zone drop only reorders a whole selected group inside the same window', async () => {
+    process.env.TARGET_BROWSER = 'chrome'
+    const selection = new Map()
+    const tab1 = { id: 1, groupId: 10, windowId: 1, index: 0 }
+    const tab2 = { id: 2, groupId: 10, windowId: 1, index: 1 }
+    const otherTab = { id: 3, groupId: -1, windowId: 1, index: 2 }
+    const moveTabs = jest.fn(() => Promise.resolve())
+    const moveGroup = jest.fn(() => Promise.resolve())
+    const groupTabs = jest.fn(() => Promise.resolve())
+    const ungroupTabs = jest.fn(() => Promise.resolve())
+    const dragStore = setupDragStore({
+      selection,
+      targetTabs: [tab1, tab2, otherTab],
+      moveTabs,
+      tabGroupStore: {
+        getTabsForGroup: jest.fn(() => [tab1, tab2]),
+        moveGroup,
+        groupTabs,
+        ungroupTabs,
+        getNoGroupId: () => -1,
+        hasTabGroupsApi: () => true,
+        canMutateGroups: () => true,
+        canMoveGroups: () => true,
+      },
+    })
+    dragStore.dragStartTab({ ...tab1, unhover: jest.fn() } as any)
+    selection.set(tab2.id, tab2 as any)
+
+    await dragStore.dropAt({
+      windowId: 1,
+      index: 3,
+      forceUngroup: true,
+      source: 'window-zone',
+    })
+
+    expect(moveGroup).toHaveBeenCalledWith(10, {
+      windowId: 1,
+      index: 1,
+    })
+    expect(ungroupTabs).not.toHaveBeenCalled()
+    expect(groupTabs).not.toHaveBeenCalled()
+    expect(moveTabs).not.toHaveBeenCalled()
+  })
+
+  it('window-zone drop detaches a partial-group selection in the same window', async () => {
+    process.env.TARGET_BROWSER = 'chrome'
+    const selection = new Map()
+    const tab1 = { id: 1, groupId: 10, windowId: 1, index: 0 }
+    const tab2 = { id: 2, groupId: 10, windowId: 1, index: 1 }
+    const tab3 = { id: 3, groupId: 10, windowId: 1, index: 2 }
+    const moveTabs = jest.fn(() => Promise.resolve())
+    const moveGroup = jest.fn(() => Promise.resolve())
+    const groupTabs = jest.fn(() => Promise.resolve())
+    const ungroupTabs = jest.fn(() => Promise.resolve())
+    const dragStore = setupDragStore({
+      selection,
+      targetTabs: [tab1, tab2, tab3],
+      moveTabs,
+      tabGroupStore: {
+        getTabsForGroup: jest.fn(() => [tab1, tab2, tab3]),
+        moveGroup,
+        groupTabs,
+        ungroupTabs,
+        getNoGroupId: () => -1,
+        hasTabGroupsApi: () => true,
+        canMutateGroups: () => true,
+        canMoveGroups: () => true,
+      },
+    })
+    dragStore.dragStartTab({ ...tab1, unhover: jest.fn() } as any)
+    selection.set(tab2.id, tab2 as any)
+
+    await dragStore.dropAt({
+      windowId: 1,
+      index: 3,
+      forceUngroup: true,
+      source: 'window-zone',
+    })
+
+    expect(ungroupTabs).toHaveBeenCalledWith([1, 2])
+    expect(moveTabs).toHaveBeenCalledWith(
+      [expect.objectContaining({ id: 1 }), expect.objectContaining({ id: 2 })],
+      1,
+      1,
+    )
+    expect(groupTabs).not.toHaveBeenCalled()
+    expect(moveGroup).not.toHaveBeenCalled()
+  })
+
+  it('window-zone drop detaches only partial-group fragments in a mixed selection', async () => {
+    process.env.TARGET_BROWSER = 'chrome'
+    const selection = new Map()
+    const wholeGroupTab1 = { id: 1, groupId: 10, windowId: 1, index: 0 }
+    const wholeGroupTab2 = { id: 2, groupId: 10, windowId: 1, index: 1 }
+    const partialGroupTab = { id: 3, groupId: 20, windowId: 1, index: 2 }
+    const partialGroupSibling = { id: 4, groupId: 20, windowId: 1, index: 3 }
+    const moveTabs = jest.fn(() => Promise.resolve())
+    const moveGroup = jest.fn(() => Promise.resolve())
+    const groupTabs = jest.fn(() => Promise.resolve())
+    const ungroupTabs = jest.fn(() => Promise.resolve())
+    const dragStore = setupDragStore({
+      selection,
+      targetTabs: [
+        wholeGroupTab1,
+        wholeGroupTab2,
+        partialGroupTab,
+        partialGroupSibling,
+      ],
+      moveTabs,
+      tabGroupStore: {
+        getTabsForGroup: jest.fn((groupId: number) => {
+          if (groupId === 10) {
+            return [wholeGroupTab1, wholeGroupTab2]
+          }
+          if (groupId === 20) {
+            return [partialGroupTab, partialGroupSibling]
+          }
+          return []
+        }),
+        moveGroup,
+        groupTabs,
+        ungroupTabs,
+        getNoGroupId: () => -1,
+        hasTabGroupsApi: () => true,
+        canMutateGroups: () => true,
+        canMoveGroups: () => true,
+      },
+    })
+    dragStore.dragStartTab({ ...wholeGroupTab1, unhover: jest.fn() } as any)
+    selection.set(wholeGroupTab2.id, wholeGroupTab2 as any)
+    selection.set(partialGroupTab.id, partialGroupTab as any)
+
+    await dragStore.dropAt({
+      windowId: 1,
+      index: 4,
+      forceUngroup: true,
+      source: 'window-zone',
+    })
+
+    expect(ungroupTabs).toHaveBeenCalledWith([3])
+    expect(moveTabs).toHaveBeenCalledWith(
+      [
+        expect.objectContaining({ id: 1 }),
+        expect.objectContaining({ id: 2 }),
+        expect.objectContaining({ id: 3 }),
+      ],
+      1,
+      1,
+    )
+    expect(groupTabs).not.toHaveBeenCalled()
+    expect(moveGroup).not.toHaveBeenCalled()
   })
 
   it('dropAt from group header should insert at start of target group', async () => {

--- a/packages/extension/src/js/stores/__tests__/DragStore.grouping.test.tsx
+++ b/packages/extension/src/js/stores/__tests__/DragStore.grouping.test.tsx
@@ -416,13 +416,13 @@ describe('DragStore with tab groups', () => {
     expect(moveGroup).not.toHaveBeenCalled()
   })
 
-  it('window-zone drop detaches only partial-group fragments in a mixed selection', async () => {
+  it('window-zone drop preserves each whole group in a mixed cross-window selection', async () => {
     process.env.TARGET_BROWSER = 'chrome'
     const selection = new Map()
-    const wholeGroupTab1 = { id: 1, groupId: 10, windowId: 1, index: 0 }
-    const wholeGroupTab2 = { id: 2, groupId: 10, windowId: 1, index: 1 }
-    const partialGroupTab = { id: 3, groupId: 20, windowId: 1, index: 2 }
-    const partialGroupSibling = { id: 4, groupId: 20, windowId: 1, index: 3 }
+    const wholeGroupTab1 = { id: 1, groupId: 10, windowId: 2, index: 0 }
+    const wholeGroupTab2 = { id: 2, groupId: 10, windowId: 2, index: 1 }
+    const partialGroupTab = { id: 3, groupId: 20, windowId: 2, index: 2 }
+    const partialGroupSibling = { id: 4, groupId: 20, windowId: 2, index: 3 }
     const moveTabs = jest.fn(() => Promise.resolve())
     const moveGroup = jest.fn(() => Promise.resolve())
     const groupTabs = jest.fn(() => Promise.resolve())
@@ -461,7 +461,7 @@ describe('DragStore with tab groups', () => {
 
     await dragStore.dropAt({
       windowId: 1,
-      index: 4,
+      index: 0,
       forceUngroup: true,
       source: 'window-zone',
     })
@@ -474,10 +474,51 @@ describe('DragStore with tab groups', () => {
         expect.objectContaining({ id: 3 }),
       ],
       1,
-      1,
+      0,
     )
-    expect(groupTabs).not.toHaveBeenCalled()
+    expect(groupTabs).toHaveBeenCalledWith([1, 2], 10)
     expect(moveGroup).not.toHaveBeenCalled()
+  })
+
+  it('window-zone drop preserves a whole group without moveGroup support', async () => {
+    process.env.TARGET_BROWSER = 'chrome'
+    const selection = new Map()
+    const tab1 = { id: 1, groupId: 10, windowId: 2, index: 0 }
+    const tab2 = { id: 2, groupId: 10, windowId: 2, index: 1 }
+    const moveTabs = jest.fn(() => Promise.resolve())
+    const groupTabs = jest.fn(() => Promise.resolve())
+    const ungroupTabs = jest.fn(() => Promise.resolve())
+    const dragStore = setupDragStore({
+      selection,
+      targetTabs: [{ id: 3, groupId: -1, windowId: 1, index: 0 }],
+      moveTabs,
+      tabGroupStore: {
+        getTabsForGroup: jest.fn(() => [tab1, tab2]),
+        groupTabs,
+        ungroupTabs,
+        getNoGroupId: () => -1,
+        hasTabGroupsApi: () => true,
+        canMutateGroups: () => true,
+        canMoveGroups: () => false,
+      },
+    })
+    dragStore.dragStartTab({ ...tab1, unhover: jest.fn() } as any)
+    selection.set(tab2.id, tab2 as any)
+
+    await dragStore.dropAt({
+      windowId: 1,
+      index: 0,
+      forceUngroup: true,
+      source: 'window-zone',
+    })
+
+    expect(moveTabs).toHaveBeenCalledWith(
+      [expect.objectContaining({ id: 1 }), expect.objectContaining({ id: 2 })],
+      1,
+      0,
+    )
+    expect(groupTabs).toHaveBeenCalledWith([1, 2], 10)
+    expect(ungroupTabs).not.toHaveBeenCalled()
   })
 
   it('dropAt from group header should insert at start of target group', async () => {

--- a/packages/extension/src/js/stores/__tests__/DragStore.grouping.test.tsx
+++ b/packages/extension/src/js/stores/__tests__/DragStore.grouping.test.tsx
@@ -892,6 +892,57 @@ describe('DragStore with tab groups', () => {
     expect(moveGroup).not.toHaveBeenCalled()
   })
 
+  it('window-zone drop preserves a whole group block and keeps loose tabs loose in a mixed cross-window selection', async () => {
+    process.env.TARGET_BROWSER = 'chrome'
+    const selection = new Map()
+    const wholeGroupTab1 = { id: 1, groupId: 10, windowId: 2, index: 0 }
+    const wholeGroupTab2 = { id: 2, groupId: 10, windowId: 2, index: 1 }
+    const looseTab = { id: 3, groupId: -1, windowId: 2, index: 2 }
+    const targetTab = { id: 4, groupId: -1, windowId: 1, index: 0 }
+    const moveTabs = jest.fn(() => Promise.resolve())
+    const moveGroup = jest.fn(() => Promise.resolve({ id: 10 }))
+    const groupTabs = jest.fn(() => Promise.resolve())
+    const ungroupTabs = jest.fn(() => Promise.resolve())
+    const dragStore = setupDragStore({
+      selection,
+      targetTabs: [targetTab],
+      moveTabs,
+      tabGroupStore: {
+        getTabsForGroup: jest.fn((groupId: number) => {
+          if (groupId === 10) {
+            return [wholeGroupTab1, wholeGroupTab2]
+          }
+          return []
+        }),
+        moveGroup,
+        groupTabs,
+        ungroupTabs,
+        getNoGroupId: () => -1,
+        hasTabGroupsApi: () => true,
+        canMutateGroups: () => true,
+        canMoveGroups: () => true,
+      },
+    })
+    dragStore.dragStartTab({ ...wholeGroupTab1, unhover: jest.fn() } as any)
+    selection.set(wholeGroupTab2.id, wholeGroupTab2 as any)
+    selection.set(looseTab.id, looseTab as any)
+
+    await dragStore.dropAt({
+      windowId: 1,
+      index: 0,
+      forceUngroup: true,
+      source: 'window-zone',
+    })
+
+    expect(moveGroup).toHaveBeenCalledWith(10, {
+      windowId: 1,
+      index: 0,
+    })
+    expect(moveTabs).toHaveBeenCalledWith([looseTab], 1, 2)
+    expect(groupTabs).not.toHaveBeenCalled()
+    expect(ungroupTabs).not.toHaveBeenCalled()
+  })
+
   it('window-zone drop preserves a whole group without moveGroup support', async () => {
     process.env.TARGET_BROWSER = 'chrome'
     const selection = new Map()

--- a/packages/integration_test/test/interaction.drag-and-drop.test.ts
+++ b/packages/integration_test/test/interaction.drag-and-drop.test.ts
@@ -29,6 +29,136 @@ const getCenterOfRect = (rect: {
   return [(left + right) / 2, (top + bottom) / 2]
 }
 
+const readFocusedTestId = async (page: Page) =>
+  await page.evaluate(
+    () => document.activeElement?.getAttribute('data-testid') || '',
+  )
+
+const focusByKeyboardUntil = async (
+  page: Page,
+  predicate: (testId: string) => boolean,
+  maxSteps = 60,
+) => {
+  let focusedTestId = await readFocusedTestId(page)
+  if (predicate(focusedTestId)) {
+    return focusedTestId
+  }
+
+  for (let index = 0; index < maxSteps; index += 1) {
+    await page.keyboard.press('j')
+    focusedTestId = await readFocusedTestId(page)
+    if (predicate(focusedTestId)) {
+      return focusedTestId
+    }
+  }
+
+  throw new Error('Unable to focus requested row by keyboard navigation')
+}
+
+const readSelectedCountState = async (page: Page) =>
+  await page.evaluate(() => {
+    const text =
+      Array.from(document.querySelectorAll('p')).find((node) =>
+        /selected/.test(node.textContent || ''),
+      )?.textContent || ''
+    const match = text.match(/,\s*(\d+)\s+tabs?\s+selected/i)
+    return match ? Number(match[1]) : -1
+  })
+
+const createWindowWithUrls = async (page: Page, urls: string[]) =>
+  await page.evaluate(async (urlsToCreate) => {
+    if (urlsToCreate.length === 0) {
+      return null
+    }
+
+    const createdWindow = await chrome.windows.create({
+      url: urlsToCreate[0],
+      focused: false,
+    })
+    const windowId = createdWindow.id
+    if (typeof windowId !== 'number') {
+      return null
+    }
+
+    for (const url of urlsToCreate.slice(1)) {
+      await chrome.tabs.create({
+        windowId,
+        url,
+        active: false,
+      })
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 600))
+    const tabs = (await chrome.tabs.query({ windowId })).sort(
+      (a, b) => (a.index ?? 0) - (b.index ?? 0),
+    )
+    const tabIdsByUrl = tabs.reduce(
+      (acc, tab) => {
+        if (tab.url && typeof tab.id === 'number') {
+          acc[tab.url] = tab.id
+        }
+        return acc
+      },
+      {} as Record<string, number>,
+    )
+
+    return {
+      windowId,
+      tabIdsByUrl,
+    }
+  }, urls)
+
+const groupTabsInWindowByUrls = async (
+  page: Page,
+  {
+    windowId,
+    urls,
+    title = '',
+    color = 'blue',
+  }: {
+    windowId: number
+    urls: string[]
+    title?: string
+    color?: string
+  },
+) =>
+  await page.evaluate(
+    async ({ windowId, urlsToGroup, title, color }) => {
+      const tabs = (await chrome.tabs.query({ windowId })).sort(
+        (a, b) => (a.index ?? 0) - (b.index ?? 0),
+      )
+      const tabIds = urlsToGroup.map(
+        (url) => tabs.find((tab) => tab.url === url)?.id ?? -1,
+      )
+      if (tabIds.some((id) => id < 0)) {
+        return null
+      }
+
+      const groupId = await chrome.tabs.group({ tabIds })
+      await chrome.tabGroups.update(groupId, {
+        title,
+        color,
+      })
+      await new Promise((resolve) => setTimeout(resolve, 300))
+      return groupId
+    },
+    { windowId, urlsToGroup: urls, title, color },
+  )
+
+const readTabsInWindow = async (page: Page, windowId: number) =>
+  await page.evaluate(async (targetWindowId) => {
+    const tabs = (await chrome.tabs.query({ windowId: targetWindowId })).sort(
+      (a, b) => (a.index ?? 0) - (b.index ?? 0),
+    )
+    return tabs.map((tab) => ({
+      id: tab.id ?? -1,
+      url: tab.url || '',
+      groupId: tab.groupId,
+      windowId: tab.windowId ?? -1,
+      index: tab.index ?? -1,
+    }))
+  }, windowId)
+
 test.describe('The Extension page should', () => {
   test.describe.configure({ mode: 'serial' })
   test.setTimeout(60000)
@@ -822,5 +952,315 @@ test.describe('The Extension page should', () => {
     expect(result.sourceGroupId).toBe(result.noGroup)
     expect(result.sourceBeforeGroup).toBe(true)
     expect(result.groupedSize).toBe(2)
+  })
+
+  test('manually selected whole group dropped into another window blank space keeps the group', async () => {
+    const sourceUrls = [
+      'data:text/html,whole-group-source-a',
+      'data:text/html,whole-group-source-b',
+    ]
+    const targetUrl = 'data:text/html,whole-group-target'
+
+    const sourceWindow = await createWindowWithUrls(page, sourceUrls)
+    const targetWindow = await createWindowWithUrls(page, [targetUrl])
+    expect(sourceWindow).toBeTruthy()
+    expect(targetWindow).toBeTruthy()
+    if (!sourceWindow || !targetWindow) {
+      return
+    }
+
+    const groupId = await groupTabsInWindowByUrls(page, {
+      windowId: sourceWindow.windowId,
+      urls: sourceUrls,
+      title: 'Whole Group',
+      color: 'blue',
+    })
+    expect(groupId).toBeGreaterThan(-1)
+    await page.reload()
+    await waitForTestId(page, `tab-group-header-${groupId}`)
+    await waitForTestId(
+      page,
+      `window-drop-zone-bottom-${targetWindow.windowId}`,
+    )
+
+    await focusByKeyboardUntil(
+      page,
+      (testId) => testId === `tab-group-header-${groupId}`,
+      60,
+    )
+    await page.keyboard.press('x')
+    await expect.poll(() => readSelectedCountState(page)).toBe(2)
+
+    await dragByTestId(page, {
+      sourceTestId: `tab-row-${sourceWindow.tabIdsByUrl[sourceUrls[0]]}`,
+      targetTestId: `window-drop-zone-bottom-${targetWindow.windowId}`,
+      dropPosition: 'middle',
+    })
+    await page.waitForTimeout(1000)
+
+    const movedTabs = await Promise.all(
+      sourceUrls.map(async (url) => {
+        const tabId = sourceWindow.tabIdsByUrl[url]
+        const tab = await page.evaluate(async (id) => {
+          const targetTab = await chrome.tabs.get(id)
+          return targetTab
+        }, tabId)
+        return tab
+      }),
+    )
+    expect(
+      movedTabs.every((tab) => tab?.windowId === targetWindow.windowId),
+    ).toBe(true)
+    expect(movedTabs.every((tab) => tab && tab.groupId === groupId)).toBe(true)
+    const targetTabs = await readTabsInWindow(page, targetWindow.windowId)
+    const targetGroupTabs = targetTabs.filter((tab) => tab.groupId === groupId)
+    expect(targetGroupTabs.map((tab) => tab.url)).toEqual(sourceUrls)
+  })
+
+  test('partial-group selection dropped into same-window blank space detaches selected tabs', async () => {
+    const urls = [
+      'data:text/html,partial-group-a',
+      'data:text/html,partial-group-b',
+      'data:text/html,partial-group-c',
+    ]
+    const setup = await createWindowWithUrls(page, urls)
+    expect(setup).toBeTruthy()
+    if (!setup) {
+      return
+    }
+
+    const groupId = await groupTabsInWindowByUrls(page, {
+      windowId: setup.windowId,
+      urls: urls.slice(0, 2),
+      title: 'Partial Group',
+      color: 'green',
+    })
+    expect(groupId).toBeGreaterThan(-1)
+    await page.reload()
+    await waitForTestId(page, `tab-group-header-${groupId}`)
+    await waitForTestId(page, `tab-row-${setup.tabIdsByUrl[urls[0]]}`)
+    await waitForTestId(page, `window-drop-zone-bottom-${setup.windowId}`)
+
+    await focusByKeyboardUntil(
+      page,
+      (testId) => testId === `tab-row-${setup.tabIdsByUrl[urls[0]]}`,
+      60,
+    )
+    await page.keyboard.press('x')
+    await expect.poll(() => readSelectedCountState(page)).toBe(1)
+
+    await dragByTestId(page, {
+      sourceTestId: `tab-row-${setup.tabIdsByUrl[urls[0]]}`,
+      targetTestId: `window-drop-zone-bottom-${setup.windowId}`,
+      dropPosition: 'middle',
+    })
+    await page.waitForTimeout(1000)
+
+    const draggedTab = await page.evaluate(async (tabId) => {
+      const tab = await chrome.tabs.get(tabId)
+      return {
+        id: tab.id ?? -1,
+        windowId: tab.windowId ?? -1,
+        groupId: tab.groupId,
+        noGroup: chrome.tabGroups.TAB_GROUP_ID_NONE,
+      }
+    }, setup.tabIdsByUrl[urls[0]])
+    expect(draggedTab.windowId).toBe(setup.windowId)
+    expect(draggedTab.groupId).toBe(draggedTab.noGroup)
+
+    const groupedTabs = await page.evaluate(async (id) => {
+      const tabs = await chrome.tabs.query({ groupId: id })
+      return tabs.map((tab) => tab.id ?? -1)
+    }, groupId)
+    expect(groupedTabs).toHaveLength(1)
+  })
+
+  test('whole group plus loose tab dropped into another window preserves the group and keeps the loose tab loose', async () => {
+    const sourceUrls = [
+      'data:text/html,mixed-selection-group-a',
+      'data:text/html,mixed-selection-group-b',
+      'data:text/html,mixed-selection-loose',
+    ]
+    const targetUrls = [
+      'data:text/html,mixed-selection-target-a',
+      'data:text/html,mixed-selection-target-b',
+    ]
+
+    const sourceWindow = await createWindowWithUrls(page, sourceUrls)
+    const targetWindow = await createWindowWithUrls(page, targetUrls)
+    expect(sourceWindow).toBeTruthy()
+    expect(targetWindow).toBeTruthy()
+    if (!sourceWindow || !targetWindow) {
+      return
+    }
+
+    const sourceGroupId = await groupTabsInWindowByUrls(page, {
+      windowId: sourceWindow.windowId,
+      urls: sourceUrls.slice(0, 2),
+      title: 'Mixed Source Group',
+      color: 'orange',
+    })
+    expect(sourceGroupId).toBeGreaterThan(-1)
+    await page.reload()
+    await waitForTestId(page, `tab-group-header-${sourceGroupId}`)
+    await waitForTestId(
+      page,
+      `tab-row-${sourceWindow.tabIdsByUrl[sourceUrls[2]]}`,
+    )
+    await waitForTestId(
+      page,
+      `window-drop-zone-bottom-${targetWindow.windowId}`,
+    )
+
+    await focusByKeyboardUntil(
+      page,
+      (testId) => testId === `tab-group-header-${sourceGroupId}`,
+      60,
+    )
+    await page.keyboard.press('x')
+    await expect.poll(() => readSelectedCountState(page)).toBe(2)
+
+    await focusByKeyboardUntil(
+      page,
+      (testId) =>
+        testId === `tab-row-${sourceWindow.tabIdsByUrl[sourceUrls[2]]}`,
+      60,
+    )
+    await page.keyboard.press('x')
+    await expect.poll(() => readSelectedCountState(page)).toBe(3)
+
+    await dragByTestId(page, {
+      sourceTestId: `tab-row-${sourceWindow.tabIdsByUrl[sourceUrls[2]]}`,
+      targetTestId: `window-drop-zone-bottom-${targetWindow.windowId}`,
+      dropPosition: 'middle',
+    })
+    await page.waitForTimeout(1000)
+
+    const movedTabs = await Promise.all(
+      sourceUrls.map(async (url) => {
+        const tabId = sourceWindow.tabIdsByUrl[url]
+        const tab = await page.evaluate(async (id) => {
+          const targetTab = await chrome.tabs.get(id)
+          return targetTab
+        }, tabId)
+        return tab
+      }),
+    )
+    expect(
+      movedTabs.every((tab) => tab?.windowId === targetWindow.windowId),
+    ).toBe(true)
+    const preservedGroupId = movedTabs[0]?.groupId ?? -1
+    expect(preservedGroupId).not.toBe(-1)
+    expect(
+      movedTabs.slice(0, 2).every((tab) => tab?.groupId === preservedGroupId),
+    ).toBe(true)
+    expect(movedTabs[2]?.groupId).toBe(-1)
+
+    const targetTabs = await readTabsInWindow(page, targetWindow.windowId)
+    const movedTargetTabs = targetTabs.filter((tab) =>
+      sourceUrls.includes(tab.url),
+    )
+    expect(movedTargetTabs).toHaveLength(3)
+  })
+
+  test('group-header center merges the entire mixed selection into the target group', async () => {
+    const sourceUrls = [
+      'data:text/html,merge-source-group-a',
+      'data:text/html,merge-source-group-b',
+      'data:text/html,merge-source-loose',
+    ]
+    const targetUrls = [
+      'data:text/html,merge-target-group-a',
+      'data:text/html,merge-target-group-b',
+    ]
+
+    const sourceWindow = await createWindowWithUrls(page, sourceUrls)
+    const targetWindow = await createWindowWithUrls(page, targetUrls)
+    expect(sourceWindow).toBeTruthy()
+    expect(targetWindow).toBeTruthy()
+    if (!sourceWindow || !targetWindow) {
+      return
+    }
+
+    const sourceGroupId = await groupTabsInWindowByUrls(page, {
+      windowId: sourceWindow.windowId,
+      urls: sourceUrls.slice(0, 2),
+      title: 'Merge Source Group',
+      color: 'purple',
+    })
+    const targetGroupId = await groupTabsInWindowByUrls(page, {
+      windowId: targetWindow.windowId,
+      urls: targetUrls,
+      title: 'Merge Target Group',
+      color: 'cyan',
+    })
+    expect(sourceGroupId).toBeGreaterThan(-1)
+    expect(targetGroupId).toBeGreaterThan(-1)
+    await page.reload()
+    await waitForTestId(page, `tab-group-header-${sourceGroupId}`)
+    await waitForTestId(page, `tab-group-header-${targetGroupId}`)
+    await waitForTestId(
+      page,
+      `tab-row-${sourceWindow.tabIdsByUrl[sourceUrls[2]]}`,
+    )
+
+    await focusByKeyboardUntil(
+      page,
+      (testId) => testId === `tab-group-header-${sourceGroupId}`,
+      60,
+    )
+    await page.keyboard.press('x')
+    await expect.poll(() => readSelectedCountState(page)).toBe(2)
+
+    await focusByKeyboardUntil(
+      page,
+      (testId) =>
+        testId === `tab-row-${sourceWindow.tabIdsByUrl[sourceUrls[2]]}`,
+      60,
+    )
+    await page.keyboard.press('x')
+    await expect.poll(() => readSelectedCountState(page)).toBe(3)
+
+    await dragByTestId(page, {
+      sourceTestId: `tab-row-${sourceWindow.tabIdsByUrl[sourceUrls[2]]}`,
+      targetTestId: `tab-group-header-${targetGroupId}`,
+      dropPosition: 'middle',
+    })
+    await page.waitForTimeout(1000)
+
+    const sourceGroupTabs = await page.evaluate(async (id) => {
+      const tabs = await chrome.tabs.query({ groupId: id })
+      return tabs.map((tab) => ({
+        id: tab.id ?? -1,
+        groupId: tab.groupId,
+        windowId: tab.windowId ?? -1,
+        url: tab.url || '',
+      }))
+    }, sourceGroupId)
+    expect(sourceGroupTabs).toHaveLength(0)
+
+    const targetTabs = await page.evaluate(async (id) => {
+      const tabs = (await chrome.tabs.query({ groupId: id })).sort(
+        (a, b) => (a.index ?? 0) - (b.index ?? 0),
+      )
+      return tabs.map((tab) => ({
+        id: tab.id ?? -1,
+        groupId: tab.groupId,
+        windowId: tab.windowId ?? -1,
+        url: tab.url || '',
+      }))
+    }, targetGroupId)
+    expect(targetTabs).toHaveLength(5)
+    expect(targetTabs.every((tab) => tab.groupId === targetGroupId)).toBe(true)
+    expect(
+      targetTabs
+        .filter((tab) => sourceUrls.includes(tab.url))
+        .map((tab) => tab.url),
+    ).toEqual(sourceUrls)
+    expect(
+      targetTabs
+        .filter((tab) => targetUrls.includes(tab.url))
+        .map((tab) => tab.url),
+    ).toEqual(targetUrls)
   })
 })


### PR DESCRIPTION
## Summary

- preserve whole selected tab groups across blank-space, group-header, and new-window drag/drop flows, including mixed selections with loose tabs
- apply the agreed whole-group vs partial-group semantics across same-window and cross-window drops, with targeted unit and integration regression coverage

Closes #2619

## Testing

- pnpm --filter tab-manager-v2 build:chrome
- ./generate_snapshots.sh
- pnpm exec eslint packages/extension/src/js/stores/DragStore.tsx packages/extension/src/js/components/Window/WindowDropZone.tsx packages/extension/src/js/components/TabGroup/GroupRow.tsx packages/extension/src/js/libs/index.tsx packages/extension/src/js/stores/__tests__/DragStore.grouping.test.tsx packages/extension/src/js/components/Window/__tests__/WindowDropZone.test.tsx packages/extension/src/js/components/TabGroup/__tests__/GroupRow.test.tsx packages/extension/src/js/libs/__tests__/index.test.tsx packages/integration_test/test/interaction.drag-and-drop.test.ts
- pnpm exec jest --maxWorkers=1 src/js/stores/__tests__/DragStore.grouping.test.tsx src/js/components/Window/__tests__/WindowDropZone.test.tsx src/js/components/TabGroup/__tests__/GroupRow.test.tsx src/js/libs/__tests__/index.test.tsx

## Release Notes

- Linux Playwright snapshot refresh was run locally via `./generate_snapshots.sh`; the Ubuntu-based run passed with `103 passed, 1 skipped` and produced no tracked `chromium-linux` baseline updates.
- Ubuntu CI is still the final remote confirmation for this branch.