### PR TITLE
chore(ci): run browser checks on Node 25

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,6 +39,7 @@ references:
   playwright_setup: &playwright_setup
     run:
       name: Install Playwright Chromium runtime
+      no_output_timeout: 20m
       command: |
         pnpm --filter integration-test exec playwright install --with-deps chromium
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ references:
 jobs:
   build-test:
     docker:
-      - image: cimg/node:lts-browsers
+      - image: cimg/node:25.9-browsers
     resource_class: large
     steps:
       - checkout
@@ -67,7 +67,7 @@ jobs:
 
   publish:
     docker:
-      - image: cimg/node:lts
+      - image: cimg/node:25.9
     steps:
       - checkout
       - *restore_cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ references:
       name: Install Playwright Chromium runtime
       no_output_timeout: 20m
       command: |
-        pnpm --filter integration-test exec playwright install --with-deps chromium
+        pnpm --filter integration-test exec playwright install --with-deps --no-shell chromium
 
 jobs:
   build-test:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -50,7 +50,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y xvfb
 
       - name: Install Playwright
-        run: pnpm --filter integration-test exec playwright install --with-deps chromium
+        run: pnpm --filter integration-test exec playwright install --with-deps --no-shell chromium
 
       # Run all test
       - name: Integration Test

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -47,13 +47,22 @@ jobs:
         run: pnpm install
 
       - name: Install xvfb
+        if: ${{ matrix.node == 25 }}
         run: sudo apt-get update && sudo apt-get install -y xvfb
 
       - name: Install Playwright
+        if: ${{ matrix.node == 25 }}
         run: pnpm --filter integration-test exec playwright install --with-deps --no-shell chromium
 
-      # Run all test
+      - name: Unit Test and Build
+        if: ${{ matrix.node == 24 }}
+        run: |
+          pnpm run test:unit
+          pnpm build
+
+      # Run all tests, including the browser integration suite.
       - name: Integration Test
+        if: ${{ matrix.node == 25 }}
         run: xvfb-run --auto-servernum --server-args="-screen 0 1280x720x24" pnpm run test
 
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -50,7 +50,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y xvfb
 
       - name: Install Playwright
-        run: pnpm --filter integration-test exec playwright install --with-deps chromium webkit
+        run: pnpm --filter integration-test exec playwright install --with-deps chromium
 
       # Run all test
       - name: Integration Test

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -109,7 +109,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y xvfb
 
       - name: Install Playwright
-        run: pnpm --filter integration-test exec playwright install --with-deps chromium
+        run: pnpm --filter integration-test exec playwright install --with-deps --no-shell chromium
 
       - name: Run release gate on Ubuntu
         run: xvfb-run --auto-servernum --server-args="-screen 0 1280x720x24" pnpm run test

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -109,7 +109,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y xvfb
 
       - name: Install Playwright
-        run: pnpm --filter integration-test exec playwright install --with-deps chromium webkit
+        run: pnpm --filter integration-test exec playwright install --with-deps chromium
 
       - name: Run release gate on Ubuntu
         run: xvfb-run --auto-servernum --server-args="-screen 0 1280x720x24" pnpm run test

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -56,10 +56,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Use Node.js 24
+      - name: Use Node.js 25
         uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version: 25
 
       - uses: pnpm/action-setup@v2
         name: Install pnpm


### PR DESCRIPTION
## Summary

- Install only the Playwright Chromium runtime used by the integration suite and skip the extra Chromium headless shell payload.
- Run browser integration checks on Node 25 while keeping Node 24 coverage for unit tests and builds.
- Align CircleCI and the release gate with the Node 25 browser-check environment.

## Testing

- `git diff --check origin/master...HEAD`
- `pnpm build`

## Release Notes

- CI-only change; no extension release note needed.
