### PR TITLE
fix: wait for settings before initial window load

### DIFF
--- a/packages/extension/src/js/stores/UserStore.tsx
+++ b/packages/extension/src/js/stores/UserStore.tsx
@@ -143,7 +143,7 @@ export default class UserStore {
     })
 
     this.store = store
-    this.init()
+    this.initPromise = this.init()
   }
 
   readSettings = async (): Promise<{ [key: string]: unknown }> => {
@@ -202,6 +202,8 @@ export default class UserStore {
       }
     }
   }
+
+  initPromise: Promise<void>
 
   init = async () => {
     const previousFontSize = this.fontSize

--- a/packages/extension/src/js/stores/WindowStore.tsx
+++ b/packages/extension/src/js/stores/WindowStore.tsx
@@ -187,9 +187,17 @@ export default class WindowsStore {
     this.windowListenersBound = true
     this.bindLifecycleLayoutRefresh()
     if (!this.initialWindowLoadStarted) {
-      this.initialWindowLoadStarted = true
-      this.getAllWindows()
+      this.initialWindowLoadPromise = this.loadInitialWindowsAfterSettings()
+      void this.initialWindowLoadPromise
     }
+  }
+
+  loadInitialWindowsAfterSettings = async () => {
+    await this.store.userStore?.initPromise
+    if (!this.windowListenersBound || this.initialWindowLoadStarted) {
+      return
+    }
+    await this.getAllWindows()
   }
 
   willUnmount = () => {
@@ -256,6 +264,8 @@ export default class WindowsStore {
   windowListenersBound = false
 
   initialWindowLoadStarted = false
+
+  initialWindowLoadPromise: Promise<void> | null = null
 
   windowLoadRequestId = 0
 

--- a/packages/extension/src/js/stores/__tests__/WindowStore.test.tsx
+++ b/packages/extension/src/js/stores/__tests__/WindowStore.test.tsx
@@ -2,6 +2,8 @@ import WindowStore from 'stores/WindowStore'
 import Window from 'stores/Window'
 import { browser, getLastFocusedWindowId } from 'libs'
 
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0))
+
 jest.mock('libs', () => ({
   browser: {
     windows: {
@@ -127,6 +129,7 @@ const createWindowStore = () => {
 describe('WindowStore layout policy', () => {
   beforeEach(() => {
     jest.restoreAllMocks()
+    ;(browser.windows.getAll as jest.Mock).mockReset()
     ;(browser.storage.local.get as jest.Mock).mockResolvedValue({
       windowLastUsedAt: {},
       tabHistory: [],
@@ -425,6 +428,51 @@ describe('WindowStore layout policy', () => {
     ])
     await loadPromise
     windowStore.willUnmount()
+  })
+
+  it('waits for user settings before the initial mount load', async () => {
+    const windowStore = createWindowStore()
+    windowStore.height = 1000
+    let resolveSettingsLoad: () => void
+    const settingsLoadPromise = new Promise<void>((resolve) => {
+      resolveSettingsLoad = resolve
+    })
+    const windows = [1, 2, 3].map((windowId) => ({
+      id: windowId,
+      tabs: [
+        {
+          id: windowId * 10,
+          index: 0,
+          windowId,
+          title: String(windowId),
+          url: 'about:blank',
+        },
+      ],
+    }))
+    windowStore.store.userStore.initPromise = settingsLoadPromise
+    ;(browser.windows.getAll as jest.Mock).mockResolvedValueOnce(windows)
+    ;(browser.storage.local.get as jest.Mock).mockResolvedValueOnce({
+      windowLastUsedAt: {
+        3: 20,
+      },
+      tabHistory: [],
+    })
+
+    try {
+      windowStore.didMount()
+      await flush()
+
+      expect(browser.windows.getAll).not.toHaveBeenCalled()
+
+      windowStore.store.userStore.windowOrder = 'lastUsed'
+      resolveSettingsLoad!()
+      await windowStore.initialWindowLoadPromise
+
+      expect(browser.windows.getAll).toHaveBeenCalledTimes(1)
+      expect(windowStore.columnLayout).toEqual([[3, 1, 2]])
+    } finally {
+      windowStore.willUnmount()
+    }
   })
 
   it('ignores an older initial load that resolves after a settings reload', async () => {


### PR DESCRIPTION
## Summary

- Prevent the initial Tab Manager window load from racing saved user settings, so `lastUsed` window order is available before the first browser window query.
- Add a regression test for the mount-time settings hydration path where pressing `s` could previously produce a different order than initial load.

Root cause: `WindowStore.didMount()` could start the initial load before `UserStore.init()` finished hydrating `windowOrder` from storage.

## Testing

- `pnpm build`
- Targeted local 1,000+ tab smoke: 16 windows x 64 tabs = 1,024 fixture tabs; initial last-used render 478ms, `s` refresh 239ms, search autocomplete 77ms.
- CI: GitHub Actions, CodeQL, CircleCI, Vercel, and PR title checks all passed.

## Release Notes

- Fix initial last-used window order so first load matches manual sync/refresh.
