### PR TITLE
fix: improve layout, drag, and search behavior

### DIFF
--- a/packages/extension/src/js/components/AutocompleteSearch/__tests__/AutocompleteSearch.test.tsx
+++ b/packages/extension/src/js/components/AutocompleteSearch/__tests__/AutocompleteSearch.test.tsx
@@ -99,11 +99,13 @@ const renderAutocompleteSearch = ({
   options = defaultOptions,
   open,
   bottomInset,
+  showResultMenu,
 }: {
   initialQuery?: string
   options?: any[]
   open?: boolean
   bottomInset?: number
+  showResultMenu?: boolean
 } = {}) => {
   const startType = jest.fn()
   const stopType = jest.fn()
@@ -151,6 +153,7 @@ const renderAutocompleteSearch = ({
         <AutocompleteSearch
           {...(open !== undefined ? { open } : {})}
           bottomInset={bottomInset}
+          showResultMenu={showResultMenu}
         />
       </AppThemeContext.Provider>
     )
@@ -184,6 +187,32 @@ describe('AutocompleteSearch', () => {
         'true',
       )
     })
+  })
+
+  it('keeps fuzzy matches while ranking stronger text matches first', async () => {
+    renderAutocompleteSearch({
+      initialQuery: 'abc',
+      open: true,
+      options: [
+        { id: 5, title: 'Archive big context', url: '', groupId: -1 },
+        { id: 4, title: 'Alpha Beta Charlie', url: '', groupId: -1 },
+        { id: 3, title: 'Project abc notes', url: '', groupId: -1 },
+        { id: 2, title: 'abc project', url: '', groupId: -1 },
+        { id: 1, title: 'abc', url: '', groupId: -1 },
+      ],
+    })
+
+    expect(
+      (await screen.findAllByRole('option')).map((option) =>
+        option.textContent?.trim(),
+      ),
+    ).toEqual([
+      'abc',
+      'abc project',
+      'Project abc notes',
+      'Alpha Beta Charlie',
+      'Archive big context',
+    ])
   })
 
   it('clears and dismisses the uncontrolled search field when Escape is pressed', async () => {
@@ -222,6 +251,39 @@ describe('AutocompleteSearch', () => {
       origin: 'search',
       reveal: true,
     })
+  })
+
+  it('hides ordinary tab results when the result menu is disabled', () => {
+    renderAutocompleteSearch({
+      initialQuery: 'tab',
+      open: true,
+      showResultMenu: false,
+    })
+
+    expect(screen.getByRole('combobox')).toHaveAttribute(
+      'aria-expanded',
+      'false',
+    )
+    expect(screen.queryByRole('option')).toBeNull()
+  })
+
+  it('keeps command results available when the result menu is disabled', async () => {
+    renderAutocompleteSearch({
+      initialQuery: '>sort',
+      showResultMenu: false,
+      options: [
+        {
+          name: 'Sort tabs',
+          command: jest.fn(),
+        },
+      ],
+    })
+
+    expect(screen.getByRole('combobox')).toHaveAttribute(
+      'aria-expanded',
+      'true',
+    )
+    expect(await screen.findByRole('option')).toHaveTextContent('Sort tabs')
   })
 
   it('uses the same smaller font size for the input text and the search hint', () => {

--- a/packages/extension/src/js/components/AutocompleteSearch/index.tsx
+++ b/packages/extension/src/js/components/AutocompleteSearch/index.tsx
@@ -261,7 +261,12 @@ const renderCommand = (
   )
 }
 
-type Props = { autoFocus?: boolean; open?: boolean; bottomInset?: number }
+type Props = {
+  autoFocus?: boolean
+  open?: boolean
+  bottomInset?: number
+  showResultMenu?: boolean
+}
 
 const LISTBOX_PADDING = 8
 
@@ -291,12 +296,18 @@ export const getAutocompleteListHeight = ({
 }
 
 const AutocompleteSearch = observer((props: Props) => {
-  const { autoFocus, open: propOpen, bottomInset = 0 } = props
+  const {
+    autoFocus,
+    open: propOpen,
+    bottomInset = 0,
+    showResultMenu = true,
+  } = props
   const theme = useAppTheme()
   const searchInputRef = useSearchInputRef()
-  const options = useOptions()
   const { userStore, searchStore, tabGroupStore } = useStore()
   const { search, query, startType, stopType, isCommand } = searchStore
+  const resultMenuEnabled = showResultMenu || isCommand
+  const options = useOptions(resultMenuEnabled)
   const tabHeight = useTabHeight()
   const rootRef = useRef<HTMLDivElement>(null)
   const isOpenControlled = propOpen !== undefined
@@ -307,14 +318,15 @@ const AutocompleteSearch = observer((props: Props) => {
   const [availableListHeight, setAvailableListHeight] = useState<number>(
     Number.POSITIVE_INFINITY,
   )
-  const isOpen = isOpenControlled ? propOpen : uncontrolledIsOpen
+  const requestedOpen = isOpenControlled ? propOpen : uncontrolledIsOpen
+  const isOpen = resultMenuEnabled && (requestedOpen || isCommand)
   const handleOpenChange = useCallback(
     (nextOpen: boolean) => {
-      if (!isOpenControlled) {
+      if (!isOpenControlled && (!nextOpen || resultMenuEnabled)) {
         setUncontrolledIsOpen(nextOpen)
       }
     },
-    [isOpenControlled],
+    [isOpenControlled, resultMenuEnabled],
   )
 
   const groupedSectionTabIdsRef = useRef(new Set())
@@ -330,8 +342,11 @@ const AutocompleteSearch = observer((props: Props) => {
   )
 
   const filteredOptions = useMemo(() => {
+    if (!resultMenuEnabled) {
+      return []
+    }
     return filterOptions(options, { inputValue: query })
-  }, [options, query, filterOptions])
+  }, [options, query, filterOptions, resultMenuEnabled])
 
   const itemCount = filteredOptions.length
 

--- a/packages/extension/src/js/components/DroppableTools.tsx
+++ b/packages/extension/src/js/components/DroppableTools.tsx
@@ -8,7 +8,11 @@ import { ItemTypes } from 'libs/react-dnd'
 import { useStore } from './hooks/useStore'
 import Tools from './Tools'
 
-export default observer(() => {
+type Props = {
+  showSearchResultMenu: boolean
+}
+
+export default observer(({ showSearchResultMenu }: Props) => {
   const { dragStore, tabStore, userStore } = useStore()
   const [dropProps, drop] = useDrop({
     accept: ItemTypes.TAB,
@@ -34,7 +38,7 @@ export default observer(() => {
         ref={drop}
         className={classNames(
           'flex items-center justify-center h-12 px-1 text-3xl shrink-0 z-10',
-          isOver ? 'bg-green-400' : 'bg-green-300'
+          isOver ? 'bg-green-400' : 'bg-green-300',
         )}
       >
         {text} in New Window
@@ -52,5 +56,5 @@ export default observer(() => {
       </div>
     )
   }
-  return <Tools />
+  return <Tools showSearchResultMenu={showSearchResultMenu} />
 })

--- a/packages/extension/src/js/components/Main.tsx
+++ b/packages/extension/src/js/components/Main.tsx
@@ -24,6 +24,8 @@ export default observer(() => {
   const { windowStore, shortcutStore, tabGroupStore, userStore } = useStore()
   const { toolbarAutoHide, litePopupMode } = userStore
   const liteMode = isPopup && litePopupMode
+  // The preference applies only to the full-page view; popup results stay on.
+  const showSearchResultMenu = isPopup || userStore.showSearchResultMenu
   const fontSize = useFontSize()
   const uiColors = getUiColorTokens(
     theme.mode === 'dark',
@@ -60,9 +62,7 @@ export default observer(() => {
         <PopupView />
       ) : (
         <>
-          <DroppableTools
-            showSearchResultMenu={isPopup || userStore.showSearchResultMenu}
-          />
+          <DroppableTools showSearchResultMenu={showSearchResultMenu} />
           <WinList />
           <Toolbar />
           <DragLayer />

--- a/packages/extension/src/js/components/Main.tsx
+++ b/packages/extension/src/js/components/Main.tsx
@@ -60,7 +60,9 @@ export default observer(() => {
         <PopupView />
       ) : (
         <>
-          <DroppableTools />
+          <DroppableTools
+            showSearchResultMenu={isPopup || userStore.showSearchResultMenu}
+          />
           <WinList />
           <Toolbar />
           <DragLayer />

--- a/packages/extension/src/js/components/Toolbar/SettingsDialog.tsx
+++ b/packages/extension/src/js/components/Toolbar/SettingsDialog.tsx
@@ -517,6 +517,8 @@ export default observer(() => {
     togglePreserveSearch,
     searchHistory,
     toggleSearchHistory,
+    showSearchResultMenu,
+    toggleShowSearchResultMenu,
     showAppWindow,
     toggleShowAppWindow,
     showUnmatchedTab,
@@ -659,6 +661,14 @@ export default observer(() => {
                 title="Include browser history in results"
                 checked={searchHistory}
                 onChange={toggleSearchHistory}
+                style={rowDetailOptionStyle}
+              />
+              <SettingsSwitchOption
+                testId="settings-search-result-menu"
+                title="Show result menu in full-page view"
+                description="Show matching tabs below search when Tab Manager is open in its own browser tab. Commands always remain available."
+                checked={showSearchResultMenu}
+                onChange={toggleShowSearchResultMenu}
                 style={rowDetailOptionStyle}
               />
               <SettingsSwitchOption

--- a/packages/extension/src/js/components/Toolbar/__tests__/SettingsDialog.test.tsx
+++ b/packages/extension/src/js/components/Toolbar/__tests__/SettingsDialog.test.tsx
@@ -47,6 +47,8 @@ const renderSettingsDialog = (theme = lightAppTheme) => {
     togglePreserveSearch: jest.fn(),
     searchHistory: false,
     toggleSearchHistory: jest.fn(),
+    showSearchResultMenu: true,
+    toggleShowSearchResultMenu: jest.fn(),
     showAppWindow: false,
     toggleShowAppWindow: jest.fn(),
     showUnmatchedTab: false,
@@ -146,6 +148,7 @@ describe('SettingsDialog', () => {
     const { userStore } = renderSettingsDialog()
 
     fireEvent.click(screen.getByTestId('settings-search-focus'))
+    fireEvent.click(screen.getByTestId('settings-search-result-menu'))
     fireEvent.click(screen.getByTestId('settings-lite-popup-mode'))
     fireEvent.click(screen.getByTestId('settings-increase-contrast'))
     fireEvent.click(
@@ -155,6 +158,7 @@ describe('SettingsDialog', () => {
     )
 
     expect(userStore.toggleAutoFocusSearch).toHaveBeenCalledTimes(1)
+    expect(userStore.toggleShowSearchResultMenu).toHaveBeenCalledTimes(1)
     expect(userStore.toggleLitePopupMode).toHaveBeenCalledTimes(1)
     expect(userStore.toggleIncreaseContrast).toHaveBeenCalledTimes(1)
     expect(

--- a/packages/extension/src/js/components/Tools.tsx
+++ b/packages/extension/src/js/components/Tools.tsx
@@ -11,7 +11,11 @@ import AutocompleteSearch from './AutocompleteSearch'
 import LayoutRepackIndicator from './LayoutRepackIndicator'
 import { getUiColorTokens } from 'libs/uiColorTokens'
 
-export default observer(() => {
+type Props = {
+  showSearchResultMenu: boolean
+}
+
+export default observer(({ showSearchResultMenu }: Props) => {
   const { userStore } = useStore()
   const theme = useAppTheme()
   const uiColors = getUiColorTokens(
@@ -38,7 +42,7 @@ export default observer(() => {
     >
       <Summary />
       <LayoutRepackIndicator />
-      <AutocompleteSearch />
+      <AutocompleteSearch showResultMenu={showSearchResultMenu} />
       <SyncButton />
       <ThemeToggle />
       <OpenInTab />

--- a/packages/extension/src/js/components/hooks/useOptions.tsx
+++ b/packages/extension/src/js/components/hooks/useOptions.tsx
@@ -1,7 +1,10 @@
 import { useStore } from 'components/hooks/useStore'
 
-export const useOptions = () => {
+export const useOptions = (enabled = true) => {
   const { windowStore, shortcutStore, searchStore } = useStore()
+  if (!enabled) {
+    return []
+  }
   if (searchStore.isCommand) {
     const { shortcuts } = shortcutStore
     return shortcuts

--- a/packages/extension/src/js/components/hooks/useOptions.tsx
+++ b/packages/extension/src/js/components/hooks/useOptions.tsx
@@ -1,9 +1,11 @@
 import { useStore } from 'components/hooks/useStore'
 
+const EMPTY_OPTIONS: never[] = []
+
 export const useOptions = (enabled = true) => {
   const { windowStore, shortcutStore, searchStore } = useStore()
   if (!enabled) {
-    return []
+    return EMPTY_OPTIONS
   }
   if (searchStore.isCommand) {
     const { shortcuts } = shortcutStore

--- a/packages/extension/src/js/stores/DragStore.tsx
+++ b/packages/extension/src/js/stores/DragStore.tsx
@@ -44,12 +44,15 @@ export default class DragStore {
 
   dragging = false
 
+  dragOriginWindowId: number | null = null
+
   dragSource: DropSource = 'tab-row'
 
   dragStartTab = (tab: Tab) => {
     tab.unhover()
     this.dropped = false
     this.dragging = true
+    this.dragOriginWindowId = tab.windowId
     this.dragSource = 'tab-row'
     const { selection, unselectAll } = this.store.tabStore
     if (!selection.has(tab.id)) {
@@ -62,13 +65,16 @@ export default class DragStore {
   dragStartGroup = (groupId: number) => {
     this.dropped = false
     this.dragging = true
+    this.dragOriginWindowId = null
     this.dragSource = 'group-header'
     const { selection, unselectAll } = this.store.tabStore
     unselectAll()
     if (this.isNoGroupId(groupId) || !this.store.tabGroupStore) {
       return selection
     }
-    this.store.tabGroupStore.getTabsForGroup(groupId).forEach((tab) => {
+    const groupTabs = this.store.tabGroupStore.getTabsForGroup(groupId)
+    this.dragOriginWindowId = groupTabs[0]?.windowId ?? null
+    groupTabs.forEach((tab) => {
       selection.set(tab.id, tab)
     })
     return selection
@@ -78,6 +84,7 @@ export default class DragStore {
 
   dragEnd = () => {
     this.dragging = false
+    this.dragOriginWindowId = null
     this.dragSource = 'tab-row'
     if (!this.dropped) {
       this.clear()

--- a/packages/extension/src/js/stores/DragStore.tsx
+++ b/packages/extension/src/js/stores/DragStore.tsx
@@ -64,16 +64,21 @@ export default class DragStore {
 
   dragStartGroup = (groupId: number) => {
     this.dropped = false
-    this.dragging = true
+    this.dragging = false
     this.dragOriginWindowId = null
-    this.dragSource = 'group-header'
+    this.dragSource = 'tab-row'
     const { selection, unselectAll } = this.store.tabStore
-    unselectAll()
     if (this.isNoGroupId(groupId) || !this.store.tabGroupStore) {
-      return selection
+      return null
     }
     const groupTabs = this.store.tabGroupStore.getTabsForGroup(groupId)
-    this.dragOriginWindowId = groupTabs[0]?.windowId ?? null
+    if (!groupTabs.length) {
+      return null
+    }
+    this.dragging = true
+    this.dragOriginWindowId = groupTabs[0].windowId
+    this.dragSource = 'group-header'
+    unselectAll()
     groupTabs.forEach((tab) => {
       selection.set(tab.id, tab)
     })

--- a/packages/extension/src/js/stores/UserStore.tsx
+++ b/packages/extension/src/js/stores/UserStore.tsx
@@ -34,6 +34,7 @@ const DEFAULT_SETTINGS = {
   showTabTooltip: true,
   preserveSearch: true,
   searchHistory: true,
+  showSearchResultMenu: true,
   showUrl: true,
   autoFocusSearch: false,
   ignoreHash: false,
@@ -104,6 +105,7 @@ export default class UserStore {
       showTabTooltip: observable,
       preserveSearch: observable,
       searchHistory: observable,
+      showSearchResultMenu: observable,
       showUrl: observable,
       autoFocusSearch: observable,
       dialogOpen: observable,
@@ -133,6 +135,7 @@ export default class UserStore {
       toggleShowTabTooltip: action,
       togglePreserveSearch: action,
       toggleSearchHistory: action,
+      toggleShowSearchResultMenu: action,
       toggleShowUnmatchedTab: action,
       toggleAutoFitColumns: action,
       toggleAutoFocusSearch: action,
@@ -257,6 +260,7 @@ export default class UserStore {
   showTabTooltip = true
   preserveSearch = true
   searchHistory = true
+  showSearchResultMenu = true
   showUrl = true
   autoFocusSearch = false
   useSystemTheme = true
@@ -398,6 +402,11 @@ export default class UserStore {
 
   toggleSearchHistory = () => {
     this.searchHistory = !this.searchHistory
+    this.save()
+  }
+
+  toggleShowSearchResultMenu = () => {
+    this.showSearchResultMenu = !this.showSearchResultMenu
     this.save()
   }
 

--- a/packages/extension/src/js/stores/WindowStore.tsx
+++ b/packages/extension/src/js/stores/WindowStore.tsx
@@ -437,10 +437,12 @@ export default class WindowsStore {
       layouts.length,
     )
     const renderedLayouts = layouts.slice(start, end)
+    const dragOriginWindowId = this.dragOriginWindowId
+    if (dragOriginWindowId === null) {
+      return renderedLayouts
+    }
     const dragOriginColumn = layouts.find((column) =>
-      column.windows.some(
-        ({ windowId }) => this.dragOriginWindowId === windowId,
-      ),
+      column.windows.some(({ windowId }) => dragOriginWindowId === windowId),
     )
     if (
       !dragOriginColumn ||

--- a/packages/extension/src/js/stores/WindowStore.tsx
+++ b/packages/extension/src/js/stores/WindowStore.tsx
@@ -303,21 +303,9 @@ export default class WindowsStore {
   }
 
   get minColumnWidthPx() {
-    const fallbackRootFontSize = 16
-    if (
-      typeof document === 'undefined' ||
-      typeof window === 'undefined' ||
-      !window.getComputedStyle
-    ) {
-      return Math.round(
-        (this.store.userStore?.tabWidth || 20) * fallbackRootFontSize,
-      )
-    }
-    const rootFontSize =
-      parseFloat(
-        window.getComputedStyle(document.documentElement).fontSize || '16',
-      ) || fallbackRootFontSize
-    return Math.round((this.store.userStore?.tabWidth || 20) * rootFontSize)
+    const tabWidth = this.store.userStore?.tabWidth || 20
+    const fontSize = this.store.userStore?.fontSize || 14
+    return Math.round(tabWidth * fontSize)
   }
 
   get autoFitColumnsEnabled() {
@@ -347,8 +335,9 @@ export default class WindowsStore {
     return Math.max(1, Math.round(Math.max(fluidWidth, this.minColumnWidthPx)))
   }
 
-  get virtualizationDisabled() {
-    return !!this.store.dragStore?.dragging
+  get dragOriginWindowId() {
+    const dragStore = this.store.dragStore
+    return dragStore?.dragging ? dragStore.dragOriginWindowId : null
   }
 
   get rawVisibleColumn() {
@@ -419,20 +408,19 @@ export default class WindowsStore {
         width: columnWidth,
         height: top,
         windows,
-        renderedWindows: this.virtualizationDisabled
-          ? windows
-          : windows.filter(
-              ({ top, bottom }) =>
-                bottom >= viewportTop - overscanPx &&
-                top <= viewportBottom + overscanPx,
-            ),
+        renderedWindows: windows.filter(
+          ({ windowId, top, bottom }) =>
+            this.dragOriginWindowId === windowId ||
+            (bottom >= viewportTop - overscanPx &&
+              top <= viewportBottom + overscanPx),
+        ),
       }
     })
   }
 
   get renderedColumnLayouts() {
     const layouts = this.columnLayoutsWithPosition
-    if (!layouts.length || this.virtualizationDisabled) {
+    if (!layouts.length) {
       return layouts
     }
 
@@ -448,7 +436,23 @@ export default class WindowsStore {
       Math.ceil(viewportRight / columnWidth) + overscanColumns,
       layouts.length,
     )
-    return layouts.slice(start, end)
+    const renderedLayouts = layouts.slice(start, end)
+    const dragOriginColumn = layouts.find((column) =>
+      column.windows.some(
+        ({ windowId }) => this.dragOriginWindowId === windowId,
+      ),
+    )
+    if (
+      !dragOriginColumn ||
+      renderedLayouts.some(
+        ({ columnIndex }) => columnIndex === dragOriginColumn.columnIndex,
+      )
+    ) {
+      return renderedLayouts
+    }
+    return [...renderedLayouts, dragOriginColumn].sort(
+      (left, right) => left.columnIndex - right.columnIndex,
+    )
   }
 
   get totalContentWidth() {
@@ -1445,7 +1449,7 @@ export default class WindowsStore {
   getVisibleRowRange = (win: Window): VisibleRowRange => {
     const rows = win.rows
     if (
-      this.virtualizationDisabled ||
+      this.dragOriginWindowId === win.id ||
       win.hide ||
       rows.length === 0 ||
       this.height <= 0

--- a/packages/extension/src/js/stores/__tests__/DragStore.grouping.test.tsx
+++ b/packages/extension/src/js/stores/__tests__/DragStore.grouping.test.tsx
@@ -109,6 +109,31 @@ describe('DragStore with tab groups', () => {
     expect(dragStore.dragOriginWindowId).toBe(8)
   })
 
+  it('dragStartGroup should cancel when the group has no tabs', () => {
+    process.env.TARGET_BROWSER = 'chrome'
+    const selection = new Map([[99, { id: 99 }]])
+    const tabStore = setupTabStore(selection)
+    const dragStore = new DragStore({
+      tabStore,
+      tabGroupStore: {
+        getTabsForGroup: jest.fn(() => []),
+        getNoGroupId: () => -1,
+        hasTabGroupsApi: () => true,
+        canMutateGroups: () => true,
+        canMoveGroups: () => true,
+      },
+    } as any)
+
+    const selected = dragStore.dragStartGroup(10)
+
+    expect(selected).toBeNull()
+    expect(tabStore.unselectAll).not.toHaveBeenCalled()
+    expect(selection.has(99)).toBe(true)
+    expect(dragStore.dragging).toBe(false)
+    expect(dragStore.dragOriginWindowId).toBeNull()
+    expect(dragStore.dragSource).toBe('tab-row')
+  })
+
   it('drop into grouped target should preserve before/after placement', async () => {
     process.env.TARGET_BROWSER = 'chrome'
     const selection = new Map()

--- a/packages/extension/src/js/stores/__tests__/DragStore.grouping.test.tsx
+++ b/packages/extension/src/js/stores/__tests__/DragStore.grouping.test.tsx
@@ -65,6 +65,7 @@ describe('DragStore with tab groups', () => {
     const tab = {
       id: 1,
       groupId: 10,
+      windowId: 7,
       select: jest.fn(),
       unhover: jest.fn(),
     }
@@ -74,14 +75,19 @@ describe('DragStore with tab groups', () => {
     expect(tab.unhover).toHaveBeenCalled()
     expect(selected.size).toBe(1)
     expect(selected.has(1)).toBe(true)
+    expect(dragStore.dragOriginWindowId).toBe(7)
     expect(getTabsForGroup).not.toHaveBeenCalled()
+
+    dragStore.dragEnd()
+
+    expect(dragStore.dragOriginWindowId).toBeNull()
   })
 
   it('dragStartGroup should select full group block', () => {
     process.env.TARGET_BROWSER = 'chrome'
     const selection = new Map([[99, { id: 99 }]])
-    const tab1 = { id: 1, groupId: 10, index: 1 }
-    const tab2 = { id: 2, groupId: 10, index: 2 }
+    const tab1 = { id: 1, groupId: 10, index: 1, windowId: 8 }
+    const tab2 = { id: 2, groupId: 10, index: 2, windowId: 8 }
     const tabStore = setupTabStore(selection)
     const dragStore = new DragStore({
       tabStore,
@@ -100,6 +106,7 @@ describe('DragStore with tab groups', () => {
     expect(selected.size).toBe(2)
     expect(selected.has(1)).toBe(true)
     expect(selected.has(2)).toBe(true)
+    expect(dragStore.dragOriginWindowId).toBe(8)
   })
 
   it('drop into grouped target should preserve before/after placement', async () => {

--- a/packages/extension/src/js/stores/__tests__/UserStore.test.tsx
+++ b/packages/extension/src/js/stores/__tests__/UserStore.test.tsx
@@ -210,6 +210,7 @@ describe('UserStore', () => {
     })
 
     expect(settings.autoFitColumns).toBe(false)
+    expect(settings.showSearchResultMenu).toBe(true)
     expect(settings.showUrl).toBe(false)
     expect(settings.uiPreset).toBe('modern')
     expect(settings).not.toHaveProperty('groupByDomain')

--- a/packages/extension/src/js/stores/__tests__/WindowStore.test.tsx
+++ b/packages/extension/src/js/stores/__tests__/WindowStore.test.tsx
@@ -208,6 +208,17 @@ describe('WindowStore layout policy', () => {
     expect(windowStore.totalContentWidth).toBeLessThanOrEqual(windowStore.width)
   })
 
+  it('derives minimum column width from the saved font size', () => {
+    const windowStore = createWindowStore()
+    windowStore.store.userStore.tabWidth = 28
+    windowStore.store.userStore.fontSize = 28
+    document.documentElement.style.fontSize = '14px'
+
+    expect(windowStore.minColumnWidthPx).toBe(784)
+
+    document.documentElement.style.fontSize = ''
+  })
+
   it('auto-fit mode reduces columns when minimum tab width increases', () => {
     const windowStore = createWindowStore()
     windowStore.height = 1000
@@ -269,8 +280,8 @@ describe('WindowStore layout policy', () => {
       windowStore.visibleWindows,
     )
 
-    expect(columnCount).toBe(4)
-    expect(layout).toEqual([[1, 5], [2, 6], [3], [4]])
+    expect(columnCount).toBe(5)
+    expect(layout).toEqual([[1, 6], [2], [3], [4], [5]])
   })
 
   it('keeps last-used window order disabled by default', () => {
@@ -573,12 +584,30 @@ describe('WindowStore layout policy', () => {
     windowStore.updateScroll(0, 0)
     expect(
       windowStore.renderedColumnLayouts.map((column) => column.columnIndex),
-    ).toEqual([0, 1])
+    ).toEqual([0, 1, 2])
 
     windowStore.updateScroll(0, 640)
     expect(
       windowStore.renderedColumnLayouts.map((column) => column.columnIndex),
     ).toEqual([1, 2, 3])
+  })
+
+  it('keeps only the drag origin column pinned outside the horizontal viewport', () => {
+    const windowStore = createWindowStore()
+    windowStore.height = 200
+    windowStore.width = 320
+    setVisibleLengths(windowStore, [4, 4, 4, 4])
+    windowStore.store.dragStore = {
+      dragging: true,
+      dragOriginWindowId: 1,
+    }
+
+    windowStore.repackLayout('manual')
+    windowStore.updateScroll(0, 960)
+
+    expect(
+      windowStore.renderedColumnLayouts.map((column) => column.columnIndex),
+    ).toEqual([0, 2, 3])
   })
 
   it('calculates visible row ranges for oversized windows', () => {
@@ -605,6 +634,45 @@ describe('WindowStore layout policy', () => {
     windowStore.repackLayout('manual')
 
     expect(windowStore.getVisibleRowRange(win)).toEqual({
+      start: 4,
+      end: 18,
+    })
+  })
+
+  it('keeps all rows mounted only for the drag origin window', () => {
+    const windowStore = createWindowStore()
+    const makeWindow = (windowId: number) =>
+      new Window(
+        {
+          id: windowId,
+          tabs: Array.from({ length: 20 }, (_, index) => ({
+            id: windowId * 100 + index,
+            index,
+            windowId,
+            title: `Tab ${windowId}-${index}`,
+            url: `https://example.com/${windowId}/${index}`,
+            groupId: -1,
+          })),
+        },
+        windowStore.store as any,
+      )
+    const sourceWindow = makeWindow(1)
+    const targetWindow = makeWindow(2)
+    windowStore.height = 200
+    windowStore.width = 320
+    windowStore.scrollTop = 400
+    windowStore.windows = [sourceWindow, targetWindow]
+    windowStore.store.dragStore = {
+      dragging: true,
+      dragOriginWindowId: sourceWindow.id,
+    }
+    windowStore.repackLayout('manual')
+
+    expect(windowStore.getVisibleRowRange(sourceWindow)).toEqual({
+      start: 0,
+      end: 20,
+    })
+    expect(windowStore.getVisibleRowRange(targetWindow)).toEqual({
       start: 4,
       end: 18,
     })

--- a/packages/integration_test/test/interaction.layout.test.ts
+++ b/packages/integration_test/test/interaction.layout.test.ts
@@ -88,6 +88,33 @@ const getRenderedWindowColumnCount = async (page: Page) => {
   return await page.locator('[data-testid^="window-column-"]').count()
 }
 
+const getRenderedWindowColumnRects = async (page: Page) => {
+  return page.evaluate(() =>
+    Array.from(
+      document.querySelectorAll<HTMLElement>('[data-testid^="window-column-"]'),
+    )
+      .map((column) => {
+        const rect = column.getBoundingClientRect()
+        return {
+          left: rect.left,
+          right: rect.right,
+          width: rect.width,
+        }
+      })
+      .sort((left, right) => left.left - right.left),
+  )
+}
+
+const expectRenderedColumnsNotToOverlap = async (page: Page) => {
+  const columnRects = await getRenderedWindowColumnRects(page)
+  expect(columnRects.length).toBeGreaterThan(1)
+  for (let index = 0; index < columnRects.length - 1; index += 1) {
+    expect(columnRects[index].right).toBeLessThanOrEqual(
+      columnRects[index + 1].left + 1,
+    )
+  }
+}
+
 const getRenderedWindowOrder = async (page: Page) => {
   return page.evaluate(() =>
     Array.from(document.querySelectorAll('[data-testid^="window-column-"]'))
@@ -722,5 +749,44 @@ test.describe('The Extension page should', () => {
 
     const metrics = await getScrollContainerMetrics(page)
     expect(metrics.scrollWidth).toBeLessThanOrEqual(metrics.clientWidth + 1)
+  })
+
+  test('large saved font size does not overlap auto-fit columns', async () => {
+    await page.setViewportSize({
+      width: 1400,
+      height: 720,
+    })
+
+    await setupAutoFitColumnsScenario(page, {
+      fontSize: 28,
+    })
+
+    await expect
+      .poll(() => getRenderedWindowColumnCount(page), { timeout: 5000 })
+      .toBe(2)
+    await expectRenderedColumnsNotToOverlap(page)
+
+    const metrics = await getScrollContainerMetrics(page)
+    expect(metrics.scrollWidth).toBeLessThanOrEqual(metrics.clientWidth + 1)
+  })
+
+  test('large saved font size uses horizontal scrolling instead of overlapping columns', async () => {
+    await page.setViewportSize({
+      width: 1400,
+      height: 720,
+    })
+
+    await setupAutoFitColumnsScenario(page, {
+      autoFitColumns: false,
+      fontSize: 28,
+    })
+
+    await expect
+      .poll(() => getRenderedWindowColumnCount(page), { timeout: 5000 })
+      .toBeGreaterThanOrEqual(4)
+    await expectRenderedColumnsNotToOverlap(page)
+
+    const metrics = await getScrollContainerMetrics(page)
+    expect(metrics.scrollWidth).toBeGreaterThan(metrics.clientWidth)
   })
 })

--- a/packages/integration_test/test/views.search.behavior.test.ts
+++ b/packages/integration_test/test/views.search.behavior.test.ts
@@ -563,6 +563,32 @@ test.describe('The Extension page should', () => {
     })
   })
 
+  test('dismiss command results on blur when ordinary results are disabled', async () => {
+    await page.evaluate(async () => {
+      const settings = { showSearchResultMenu: false }
+      await chrome.storage.local.set(settings)
+      await chrome.storage.sync?.set?.(settings)
+    })
+    await page.reload()
+    await waitForDefaultExtensionView(page)
+
+    const searchInput = page.locator(
+      'input[placeholder*="Search tabs or URLs"]',
+    )
+    await searchInput.click()
+    await searchInput.fill('>')
+
+    const listbox = page.getByRole('listbox')
+    await expect(searchInput).toHaveAttribute('aria-expanded', 'true')
+    await expect(listbox).toBeVisible()
+
+    await searchInput.press('Tab')
+
+    await expect(searchInput).toHaveValue('')
+    await expect(searchInput).toHaveAttribute('aria-expanded', 'false')
+    await expect(listbox).toBeHidden()
+  })
+
   test('keep search open during non-option popup interaction', async () => {
     const urls = Array.from(
       { length: 22 },


### PR DESCRIPTION
## Summary

- prevent column overlap by deriving minimum column width from the persisted tab width and font size
- keep non-origin windows virtualized during drag operations to improve large-workspace responsiveness
- add a persisted full-page search result menu preference while keeping commands available
- preserve the existing fuzzy-ranking contract in the dropdown with regression coverage while retaining browser order in the main grid
- incorporate review follow-ups for no-drag layout scanning, empty group drags, and command-menu dismissal

Addresses feedback from #2637.

## Testing

- `pnpm build` (Chrome and Firefox)
- `pnpm exec jest --maxWorkers=1 src/js/stores/__tests__/WindowStore.test.tsx` — 40 passed
- `pnpm exec jest --maxWorkers=1 src/js/stores/__tests__/DragStore.grouping.test.tsx` — 25 passed
- `pnpm exec jest --maxWorkers=1 src/js/components/AutocompleteSearch/__tests__/AutocompleteSearch.test.tsx` — 9 passed
- command-result blur regression in Chromium — 1 passed
- targeted macOS Chromium overlap integration checks — 2 passed
- Linux Chromium integration and visual verification — 111 passed, 1 skipped
- `git diff --check`

## Release Notes

- Fix column overlap at larger font sizes and improve drag performance in large workspaces.
- Add an option to hide the full-page search result menu without disabling command search.