### PR TITLE
chore(ci): isolate browser store publishing jobs

### DIFF
--- a/.github/release-automation.md
+++ b/.github/release-automation.md
@@ -10,8 +10,10 @@ Linux Playwright gate, and submits the release to Chrome, Firefox, and Edge.
 1. Merge releasable commits such as `fix:` or `feat:` into `master`.
 2. `.github/workflows/release-please.yml` opens or updates one release PR.
 3. Merge the release PR after the Linux CI gate passes.
-4. The same workflow detects that a GitHub Release was created, rebuilds on
-   Ubuntu, uploads release artifacts, and runs `pnpm run publish-extension`.
+4. The same workflow detects that a GitHub Release was created and runs the
+   Linux release gate without browser-store credentials.
+5. That job uploads one checksummed artifact, which independent jobs attach to
+   the GitHub Release and submit to Chrome, Firefox, and Edge.
 
 ## Keeping changes releasable
 
@@ -141,11 +143,25 @@ instructions.
   4. Click `Create API credentials`.
   5. Copy the Client ID and API key into GitHub.
 
+Microsoft's v1.1 API keys are
+[valid for 72 days](https://blogs.windows.com/msedgedev/2025/01/08/enhanced-security-for-extensions-with-publish-api-next-steps/).
+Record the expiry shown in Partner Center and rotate `EDGE_API_KEY` before it
+expires. Keep `EDGE_CLIENT_ID` paired with the credentials shown by Partner
+Center, updating it too if Partner Center issues a new Client ID.
+
 ## Notes
 
 - The publish workflow intentionally reruns on Ubuntu before store submission,
   because popup and snapshot-sensitive UI verification in this repository must
   be trusted on Linux rather than local macOS runs.
+- Browser-store credentials are scoped to their store's final publishing step.
+  Checkout, dependency installation, tests, builds, checksum verification, and
+  the other store jobs cannot read them.
+- Chrome, Firefox, and Edge publish independently from the same immutable
+  artifact. If one store fails, use GitHub Actions' **Re-run failed jobs** to
+  retry only that store without resubmitting successful stores.
+- Configure the `chrome-web-store`, `firefox-amo`, and `edge-addons` GitHub
+  environments with any desired approval or deployment-branch protections.
 - Firefox submission is asynchronous from CI's point of view. A successful
   workflow means the package was submitted, not necessarily that AMO review has
   completed.

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -7,17 +7,19 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
-  issues: write
-  pull-requests: write
+  contents: read
 
 concurrency:
   group: release-please-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
     outputs:
       extension_release_created: ${{ steps.release.outputs['packages/extension--release_created'] }}
       extension_tag_name: ${{ steps.release.outputs['packages/extension--tag_name'] }}
@@ -33,28 +35,21 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
-  publish-extension:
-    name: Publish Extension
+  build-release:
+    name: Build Release
     needs: release-please
     if: ${{ needs.release-please.outputs.extension_release_created == 'true' }}
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
     concurrency:
-      group: publish-extension-${{ needs.release-please.outputs.extension_tag_name }}
+      group: build-release-${{ needs.release-please.outputs.extension_tag_name }}
       cancel-in-progress: false
-    env:
-      EXTENSION_ID: ${{ secrets.EXTENSION_ID }}
-      CHROME_PUBLISHER_ID: ${{ secrets.CHROME_PUBLISHER_ID }}
-      CHROME_SERVICE_ACCOUNT_JSON: ${{ secrets.CHROME_SERVICE_ACCOUNT_JSON }}
-      WEB_EXT_API_KEY: ${{ secrets.WEB_EXT_API_KEY }}
-      WEB_EXT_API_SECRET: ${{ secrets.WEB_EXT_API_SECRET }}
-      EDGE_PRODUCT_ID: ${{ secrets.EDGE_PRODUCT_ID }}
-      EDGE_CLIENT_ID: ${{ secrets.EDGE_CLIENT_ID }}
-      EDGE_API_KEY: ${{ secrets.EDGE_API_KEY }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.release-please.outputs.extension_tag_name }}
 
       - name: Use Node.js 25
         uses: actions/setup-node@v4
@@ -84,27 +79,6 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Verify release credentials
-        shell: bash
-        run: |
-          missing=0
-          for var in \
-            EXTENSION_ID \
-            CHROME_PUBLISHER_ID \
-            CHROME_SERVICE_ACCOUNT_JSON \
-            WEB_EXT_API_KEY \
-            WEB_EXT_API_SECRET \
-            EDGE_PRODUCT_ID \
-            EDGE_CLIENT_ID \
-            EDGE_API_KEY
-          do
-            if [ -z "${!var}" ]; then
-              echo "::error::Missing required secret for ${var}"
-              missing=1
-            fi
-          done
-          exit "$missing"
-
       - name: Install xvfb
         run: sudo apt-get update && sudo apt-get install -y xvfb
 
@@ -118,10 +92,15 @@ jobs:
         run: |
           pnpm run deploy
           pnpm run package:firefox-source
+          cd packages/extension
+          sha256sum \
+            build/build_chrome.zip \
+            build/build_firefox.zip \
+            build/build_firefox_source.zip \
+            > build/SHA256SUMS.txt
 
       - name: Upload packaged extension artifacts
         uses: actions/upload-artifact@v4
-        if: ${{ !cancelled() }}
         with:
           name: extension-release-${{ needs.release-please.outputs.extension_tag_name }}
           path: |
@@ -131,16 +110,165 @@ jobs:
             packages/extension/build/SHA256SUMS.txt
           retention-days: 30
 
-      - name: Attach build artifacts to the GitHub release
+  attach-release-assets:
+    name: Attach Release Assets
+    needs: [release-please, build-release]
+    if: ${{ needs.release-please.outputs.extension_release_created == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download packaged extension artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: extension-release-${{ needs.release-please.outputs.extension_tag_name }}
+          path: packages/extension/build
+
+      - name: Verify release artifacts
+        working-directory: packages/extension
+        run: sha256sum --check build/SHA256SUMS.txt
+
+      - name: Attach artifacts to the GitHub release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release upload "${{ needs.release-please.outputs.extension_tag_name }}" \
+          gh release upload \
+            "${{ needs.release-please.outputs.extension_tag_name }}" \
             packages/extension/build/build_chrome.zip \
             packages/extension/build/build_firefox.zip \
             packages/extension/build/build_firefox_source.zip \
             packages/extension/build/SHA256SUMS.txt \
-            --clobber
+            --clobber \
+            --repo "${{ github.repository }}"
 
-      - name: Publish to browser stores
-        run: pnpm run publish-extension
+  publish-chrome:
+    name: Publish Chrome
+    needs: [release-please, build-release]
+    if: ${{ needs.release-please.outputs.extension_release_created == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    environment: chrome-web-store
+    concurrency:
+      group: publish-chrome-${{ needs.release-please.outputs.extension_tag_name }}
+      cancel-in-progress: false
+    steps:
+      - name: Checkout release
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.release-please.outputs.extension_tag_name }}
+
+      - name: Use Node.js 25
+        uses: actions/setup-node@v4
+        with:
+          node-version: 25
+
+      - name: Download packaged extension artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: extension-release-${{ needs.release-please.outputs.extension_tag_name }}
+          path: packages/extension/build
+
+      - name: Verify release artifacts
+        working-directory: packages/extension
+        run: sha256sum --check build/SHA256SUMS.txt
+
+      - name: Publish to Chrome Web Store
+        env:
+          EXTENSION_ID: ${{ secrets.EXTENSION_ID }}
+          CHROME_PUBLISHER_ID: ${{ secrets.CHROME_PUBLISHER_ID }}
+          CHROME_SERVICE_ACCOUNT_JSON: ${{ secrets.CHROME_SERVICE_ACCOUNT_JSON }}
+        run: node ./publish_chrome.mjs
+
+  publish-firefox:
+    name: Publish Firefox
+    needs: [release-please, build-release]
+    if: ${{ needs.release-please.outputs.extension_release_created == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    environment: firefox-amo
+    concurrency:
+      group: publish-firefox-${{ needs.release-please.outputs.extension_tag_name }}
+      cancel-in-progress: false
+    steps:
+      - name: Checkout release
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.release-please.outputs.extension_tag_name }}
+
+      - name: Use Node.js 25
+        uses: actions/setup-node@v4
+        with:
+          node-version: 25
+
+      - uses: pnpm/action-setup@v2
+        name: Install pnpm
+        with:
+          version: 9
+          run_install: false
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Download packaged extension artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: extension-release-${{ needs.release-please.outputs.extension_tag_name }}
+          path: packages/extension/build
+
+      - name: Verify release artifacts
+        working-directory: packages/extension
+        run: sha256sum --check build/SHA256SUMS.txt
+
+      - name: Expand Firefox package
+        run: |
+          mkdir -p packages/extension/build/build_firefox
+          unzip -q \
+            packages/extension/build/build_firefox.zip \
+            -d packages/extension/build/build_firefox
+
+      - name: Submit to Firefox Add-ons
+        env:
+          WEB_EXT_API_KEY: ${{ secrets.WEB_EXT_API_KEY }}
+          WEB_EXT_API_SECRET: ${{ secrets.WEB_EXT_API_SECRET }}
+        run: pnpm run publish:firefox:sign
+
+  publish-edge:
+    name: Publish Edge
+    needs: [release-please, build-release]
+    if: ${{ needs.release-please.outputs.extension_release_created == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    environment: edge-addons
+    concurrency:
+      group: publish-edge-${{ needs.release-please.outputs.extension_tag_name }}
+      cancel-in-progress: false
+    steps:
+      - name: Checkout release
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.release-please.outputs.extension_tag_name }}
+
+      - name: Use Node.js 25
+        uses: actions/setup-node@v4
+        with:
+          node-version: 25
+
+      - name: Download packaged extension artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: extension-release-${{ needs.release-please.outputs.extension_tag_name }}
+          path: packages/extension/build
+
+      - name: Verify release artifacts
+        working-directory: packages/extension
+        run: sha256sum --check build/SHA256SUMS.txt
+
+      - name: Publish to Microsoft Edge Add-ons
+        env:
+          EDGE_PRODUCT_ID: ${{ secrets.EDGE_PRODUCT_ID }}
+          EDGE_CLIENT_ID: ${{ secrets.EDGE_CLIENT_ID }}
+          EDGE_API_KEY: ${{ secrets.EDGE_API_KEY }}
+        run: node ./publish_edge.mjs


### PR DESCRIPTION
## Summary

- build and checksum release artifacts once in a store-credential-free Ubuntu job, then attach them to the GitHub release separately
- publish Chrome, Firefox, and Edge independently with store-specific environments and credentials scoped to each final publish step
- document failed-job retry behavior and Microsoft Edge's 72-day API-key rotation requirement

## Testing

- `pnpm build`
- `pnpm exec prettier --check .github/workflows/release-please.yml .github/release-automation.md`
- parsed `.github/workflows/release-please.yml` with Ruby YAML
- `git diff --check`

The refactored workflow has not yet executed on GitHub; its first Ubuntu release run remains the end-to-end verification.

## Release Notes

- None; this changes release infrastructure only and does not alter the extension package.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release Process Improvements**
  - Release packages are now built once and verified with checksums before distribution.
  - Chrome, Firefox, and Edge submissions run independently, allowing targeted retries when one submission encounters an issue.
  - Release assets are automatically attached to the corresponding GitHub Release.
- **Documentation**
  - Updated release automation guidance, including credential handling, approval settings, and Microsoft Edge publishing requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->