### PR TITLE
chore(ci): add Edge release retry workflow

### DIFF
--- a/.github/workflows/retry-edge-release.yml
+++ b/.github/workflows/retry-edge-release.yml
@@ -1,0 +1,59 @@
+name: Retry Edge Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Existing GitHub release tag to submit to Edge
+        required: true
+        default: v2.4.1
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  publish-edge:
+    name: Publish Edge (${{ inputs.release_tag }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment: edge-addons
+    concurrency:
+      group: publish-edge-${{ inputs.release_tag }}
+      cancel-in-progress: false
+    steps:
+      - name: Checkout release
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.release_tag }}
+
+      - name: Use Node.js 25
+        uses: actions/setup-node@v4
+        with:
+          node-version: 25
+
+      - name: Download Chrome package from the GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+        run: |
+          mkdir -p packages/extension/build
+          gh release download "$RELEASE_TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --pattern build_chrome.zip \
+            --pattern SHA256SUMS.txt \
+            --dir packages/extension/build
+
+      - name: Verify Chrome package checksum
+        working-directory: packages/extension
+        run: |
+          grep -E '  build/build_chrome\.zip$' build/SHA256SUMS.txt \
+            | sha256sum --check -
+
+      - name: Publish to Microsoft Edge Add-ons
+        env:
+          EDGE_PRODUCT_ID: ${{ secrets.EDGE_PRODUCT_ID }}
+          EDGE_CLIENT_ID: ${{ secrets.EDGE_CLIENT_ID }}
+          EDGE_API_KEY: ${{ secrets.EDGE_API_KEY }}
+          EDGE_SUBMISSION_NOTES: Retry GitHub release ${{ inputs.release_tag }}
+        run: node ./publish_edge.mjs

--- a/.github/workflows/retry-edge-release.yml
+++ b/.github/workflows/retry-edge-release.yml
@@ -15,6 +15,7 @@ permissions:
 jobs:
   publish-edge:
     name: Publish Edge (${{ inputs.release_tag }})
+    if: ${{ github.ref_name == github.event.repository.default_branch }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment: edge-addons
@@ -22,15 +23,39 @@ jobs:
       group: publish-edge-${{ inputs.release_tag }}
       cancel-in-progress: false
     steps:
-      - name: Checkout release
+      - name: Checkout trusted publisher
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.release_tag }}
+          ref: ${{ github.sha }}
+          persist-credentials: false
 
-      - name: Use Node.js 25
+      - name: Use Node.js 24 LTS
         uses: actions/setup-node@v4
         with:
-          node-version: 25
+          node-version: 24
+
+      - name: Validate published release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+        run: |
+          if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Release tag must use the vMAJOR.MINOR.PATCH format"
+            exit 1
+          fi
+
+          release_state="$(gh release view "$RELEASE_TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --json tagName,isDraft,isPrerelease \
+            --jq '[.tagName, .isDraft, .isPrerelease] | @tsv')"
+          IFS=$'\t' read -r actual_tag is_draft is_prerelease <<< "$release_state"
+
+          if [[ "$actual_tag" != "$RELEASE_TAG" || \
+                "$is_draft" != "false" || \
+                "$is_prerelease" != "false" ]]; then
+            echo "::error::Release must be a published, non-prerelease GitHub Release"
+            exit 1
+          fi
 
       - name: Download Chrome package from the GitHub release
         env:


### PR DESCRIPTION
## Summary

- add a manual `Retry Edge Release` workflow with an existing release-tag input, defaulting to `v2.4.1`
- run the publisher from the trusted workflow SHA on the default branch with persisted checkout credentials disabled
- require a published, non-prerelease semantic-version GitHub Release, then download and checksum its Chrome ZIP before submission
- expose the Edge product ID, Client ID, and API key only to the final Edge publishing step in the `edge-addons` environment
- use Node.js 24 LTS for the recovery job

## Testing

- `pnpm build`
- `pnpm exec prettier --check .github/workflows/retry-edge-release.yml`
- parsed `.github/workflows/retry-edge-release.yml` with Ruby YAML
- `git diff --check`
- validated that the real `v2.4.1` release is published and is not a prerelease
- downloaded the real `v2.4.1` `build_chrome.zip` and `SHA256SUMS.txt` assets and verified `build/build_chrome.zip: OK` with the same commands used by the workflow

The Edge submission itself has not been triggered; that should happen only after review and merge.

## Release Notes

- None; this adds a manual release-recovery workflow and does not alter the extension package.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a manually triggered “Retry Edge Release” workflow that republishing to Microsoft Edge Add-ons for a specified release tag.
  * Validates the chosen GitHub release is published and matches the expected version format.
  * Downloads the required build artifacts and verifies the ZIP against the provided SHA-256 checksums before submission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->