### PR TITLE
fix: preserve last-used window order

### DIFF
--- a/packages/extension/src/js/stores/WindowStore.tsx
+++ b/packages/extension/src/js/stores/WindowStore.tsx
@@ -828,6 +828,9 @@ export default class WindowsStore {
       }
     })
 
+    if (this.autoFitColumnsEnabled) {
+      return this.computeOrderedAutoFitColumnLayout(orderedWindows)
+    }
     return this.computeBaseColumnLayout(orderedWindows)
   }
 
@@ -850,14 +853,19 @@ export default class WindowsStore {
 
   getWindowIdsToPromoteByLastUsed = (windows: Window[]) => {
     const visibleWindowIds = new Set(windows.map((win) => win.id))
+    const lastUsedWindowIds = this.getLastUsedWindowIds(windows)
     if (
       typeof this.pendingLastUsedWindowId === 'number' &&
       visibleWindowIds.has(this.pendingLastUsedWindowId)
     ) {
-      return [this.pendingLastUsedWindowId]
+      return [
+        this.pendingLastUsedWindowId,
+        ...lastUsedWindowIds.filter(
+          (windowId) => windowId !== this.pendingLastUsedWindowId,
+        ),
+      ]
     }
-    const [lastUsedWindowId] = this.getLastUsedWindowIds(windows)
-    return typeof lastUsedWindowId === 'number' ? [lastUsedWindowId] : []
+    return lastUsedWindowIds
   }
 
   getLastUsedPromotedColumnLayout = (
@@ -878,10 +886,7 @@ export default class WindowsStore {
         windowIdsToPromote,
       }
     }
-    const currentWindowIds = this.getWindowIdOrderFromColumnLayout(
-      currentLayout,
-      windows,
-    )
+    const currentWindowIds = windows.map((win) => win.id)
     const nextWindowIds = this.promoteWindowIdsInOrder(
       currentWindowIds,
       windowIdsToPromote,
@@ -1039,6 +1044,55 @@ export default class WindowsStore {
     }
   }
 
+  computeOrderedAutoFitColumnLayout = (windows: Window[]) => {
+    if (!windows.length) {
+      return {
+        layout: [[]],
+        columnCount: 1,
+      }
+    }
+
+    const columnCount = this.getAutoFitColumnCount(windows.length)
+    const layout = Array.from({ length: columnCount }, () => [] as number[])
+    const windowHeights = windows.map((win) => win.visibleLength)
+    let remainingHeight = windowHeights.reduce(
+      (total, windowHeight) => total + windowHeight,
+      0,
+    )
+    let windowIndex = 0
+
+    for (let columnIndex = 0; columnIndex < columnCount; columnIndex += 1) {
+      const remainingColumnCount = columnCount - columnIndex
+      const targetHeight = remainingHeight / remainingColumnCount
+      let columnHeight = 0
+
+      while (windowIndex < windows.length) {
+        const remainingWindowCount = windows.length - windowIndex
+        if (remainingWindowCount <= remainingColumnCount - 1) {
+          break
+        }
+        const nextWindowHeight = windowHeights[windowIndex]
+        if (
+          layout[columnIndex].length > 0 &&
+          Math.abs(targetHeight - columnHeight) <=
+            Math.abs(targetHeight - (columnHeight + nextWindowHeight))
+        ) {
+          break
+        }
+        layout[columnIndex].push(windows[windowIndex].id)
+        columnHeight += nextWindowHeight
+        windowIndex += 1
+      }
+
+      remainingHeight -= columnHeight
+    }
+
+    return {
+      layout,
+      columnCount,
+    }
+  }
+
   computeColumnLayout = (windows: Window[]) => {
     const computed = this.computeBaseColumnLayout(windows)
     if (
@@ -1092,6 +1146,12 @@ export default class WindowsStore {
       this.shouldResetWindowLastUsedColumnLayoutForRepack(reason)
     ) {
       this.windowLastUsedColumnLayout = null
+    }
+    if (
+      this.hasWindowLastUsedLayoutCandidate() &&
+      this.applyWindowLastUsedLayout(reason)
+    ) {
+      return
     }
     const { layout, columnCount } = this.computeColumnLayout(
       this.visibleWindows,

--- a/packages/extension/src/js/stores/WindowStore.tsx
+++ b/packages/extension/src/js/stores/WindowStore.tsx
@@ -1053,38 +1053,65 @@ export default class WindowsStore {
     }
 
     const columnCount = this.getAutoFitColumnCount(windows.length)
-    const layout = Array.from({ length: columnCount }, () => [] as number[])
     const windowHeights = windows.map((win) => win.visibleLength)
-    let remainingHeight = windowHeights.reduce(
-      (total, windowHeight) => total + windowHeight,
-      0,
+    const cumulativeHeights = windowHeights.reduce(
+      (totals, windowHeight) => {
+        totals.push(totals[totals.length - 1] + windowHeight)
+        return totals
+      },
+      [0],
     )
-    let windowIndex = 0
+    const minimumMaxHeights = Array.from({ length: columnCount + 1 }, () =>
+      Array(windows.length + 1).fill(Number.POSITIVE_INFINITY),
+    )
+    const splitIndexes = Array.from({ length: columnCount + 1 }, () =>
+      Array(windows.length + 1).fill(0),
+    )
+    minimumMaxHeights[0][0] = 0
 
-    for (let columnIndex = 0; columnIndex < columnCount; columnIndex += 1) {
-      const remainingColumnCount = columnCount - columnIndex
-      const targetHeight = remainingHeight / remainingColumnCount
-      let columnHeight = 0
-
-      while (windowIndex < windows.length) {
-        const remainingWindowCount = windows.length - windowIndex
-        if (remainingWindowCount <= remainingColumnCount - 1) {
-          break
-        }
-        const nextWindowHeight = windowHeights[windowIndex]
-        if (
-          layout[columnIndex].length > 0 &&
-          Math.abs(targetHeight - columnHeight) <=
-            Math.abs(targetHeight - (columnHeight + nextWindowHeight))
+    for (
+      let partitionCount = 1;
+      partitionCount <= columnCount;
+      partitionCount += 1
+    ) {
+      for (
+        let endIndex = partitionCount;
+        endIndex <= windows.length;
+        endIndex += 1
+      ) {
+        for (
+          let splitIndex = partitionCount - 1;
+          splitIndex < endIndex;
+          splitIndex += 1
         ) {
-          break
+          const partitionHeight =
+            cumulativeHeights[endIndex] - cumulativeHeights[splitIndex]
+          const candidateMaxHeight = Math.max(
+            minimumMaxHeights[partitionCount - 1][splitIndex],
+            partitionHeight,
+          )
+          if (
+            candidateMaxHeight < minimumMaxHeights[partitionCount][endIndex]
+          ) {
+            minimumMaxHeights[partitionCount][endIndex] = candidateMaxHeight
+            splitIndexes[partitionCount][endIndex] = splitIndex
+          }
         }
-        layout[columnIndex].push(windows[windowIndex].id)
-        columnHeight += nextWindowHeight
-        windowIndex += 1
       }
+    }
 
-      remainingHeight -= columnHeight
+    const layout = Array.from({ length: columnCount }, () => [] as number[])
+    let endIndex = windows.length
+    for (
+      let partitionCount = columnCount;
+      partitionCount > 0;
+      partitionCount -= 1
+    ) {
+      const splitIndex = splitIndexes[partitionCount][endIndex]
+      layout[partitionCount - 1] = windows
+        .slice(splitIndex, endIndex)
+        .map((win) => win.id)
+      endIndex = splitIndex
     }
 
     return {

--- a/packages/extension/src/js/stores/__tests__/WindowStore.test.tsx
+++ b/packages/extension/src/js/stores/__tests__/WindowStore.test.tsx
@@ -287,6 +287,32 @@ describe('WindowStore layout policy', () => {
     expect(layout).toEqual([[1], [2], [3], [4], [5, 6]])
   })
 
+  it('optimally balances ordered auto-fit columns with unequal heights', () => {
+    const windowStore = createWindowStore()
+    windowStore.store.userStore.autoFitColumns = true
+    windowStore.width = 1120
+    setVisibleLengths(windowStore, [7, 2, 4, 5, 9, 5])
+
+    const { layout, columnCount } =
+      windowStore.computeOrderedAutoFitColumnLayout(windowStore.visibleWindows)
+
+    expect(columnCount).toBe(4)
+    expect(layout).toEqual([[1, 2], [3, 4], [5], [6]])
+  })
+
+  it('uses stable split positions when ordered auto-fit partitions tie', () => {
+    const windowStore = createWindowStore()
+    windowStore.store.userStore.autoFitColumns = true
+    windowStore.width = 1400
+    setVisibleLengths(windowStore, [1, 1, 1, 1, 1, 1])
+
+    const { layout, columnCount } =
+      windowStore.computeOrderedAutoFitColumnLayout(windowStore.visibleWindows)
+
+    expect(columnCount).toBe(5)
+    expect(layout).toEqual([[1], [2], [3], [4], [5, 6]])
+  })
+
   it('keeps last-used window order disabled by default', () => {
     const windowStore = createWindowStore()
     windowStore.height = 260

--- a/packages/extension/src/js/stores/__tests__/WindowStore.test.tsx
+++ b/packages/extension/src/js/stores/__tests__/WindowStore.test.tsx
@@ -284,7 +284,7 @@ describe('WindowStore layout policy', () => {
     )
 
     expect(columnCount).toBe(5)
-    expect(layout).toEqual([[1, 6], [2], [3], [4], [5]])
+    expect(layout).toEqual([[1], [2], [3], [4], [5, 6]])
   })
 
   it('keeps last-used window order disabled by default', () => {
@@ -321,7 +321,7 @@ describe('WindowStore layout policy', () => {
     expect(layout).toEqual([[5, 1], [2, 3], [4]])
   })
 
-  it('promotes only the newest last-used window and keeps the rest stable', () => {
+  it('reconstructs the complete last-used window order from timestamps', () => {
     const windowStore = createWindowStore()
     windowStore.store.userStore.windowOrder = 'lastUsed'
     windowStore.height = 1000
@@ -336,7 +336,59 @@ describe('WindowStore layout policy', () => {
       windowStore.visibleWindows,
     )
 
-    expect(layout).toEqual([[2, 1, 3, 4]])
+    expect(layout).toEqual([[2, 4, 1, 3]])
+  })
+
+  it('keeps the complete last-used order across auto-fit column resizing', () => {
+    const windowStore = createWindowStore()
+    windowStore.store.userStore.windowOrder = 'lastUsed'
+    windowStore.store.userStore.autoFitColumns = true
+    windowStore.height = 1000
+    windowStore.width = 560
+    setVisibleLengths(windowStore, [1, 1, 1, 1, 1, 1])
+    windowStore.windowLastUsedAt = {
+      6: 20,
+      5: 10,
+    }
+
+    windowStore.repackLayout('settings-change')
+    expect(windowStore.columnLayout).toEqual([
+      [6, 5, 1],
+      [2, 3, 4],
+    ])
+
+    windowStore.updateViewport(1000, 840)
+
+    expect(windowStore.columnLayout).toEqual([
+      [6, 5],
+      [1, 2],
+      [3, 4],
+    ])
+    expect(windowStore.windowLastUsedColumnLayout).toEqual([
+      [6, 5],
+      [1, 2],
+      [3, 4],
+    ])
+  })
+
+  it('restores untimestamped windows in fallback order after filtering', () => {
+    const windowStore = createWindowStore()
+    windowStore.store.userStore.windowOrder = 'lastUsed'
+    windowStore.height = 1000
+    setVisibleLengths(windowStore, [1, 1, 1, 1])
+    windowStore.windowLastUsedAt = {
+      2: 20,
+      4: 10,
+    }
+
+    windowStore.repackLayout('filter-change')
+    expect(windowStore.columnLayout).toEqual([[2, 4, 1, 3]])
+    ;(windowStore.windows[0] as any).visibleLength = 0
+    windowStore.repackLayout('filter-change')
+    expect(windowStore.columnLayout).toEqual([[2, 4, 3]])
+    ;(windowStore.windows[0] as any).visibleLength = 1
+    windowStore.repackLayout('filter-change')
+    expect(windowStore.columnLayout).toEqual([[2, 4, 1, 3]])
   })
 
   it('clears dirty state when applying last-used order keeps the same layout', () => {

--- a/packages/integration_test/test/interaction.layout.test.ts
+++ b/packages/integration_test/test/interaction.layout.test.ts
@@ -1112,6 +1112,76 @@ test.describe('The Extension page should', () => {
       .toEqual([lastUsedWindowId, ...createdWindowIds.slice(0, 2)])
   })
 
+  test('last-used window order survives reload and sync', async () => {
+    await page.setViewportSize({
+      width: 1400,
+      height: 720,
+    })
+    const createdWindowIds = await createWindowsWithTabs(page, [
+      ['about:blank#window-order-persisted-1'],
+      ['about:blank#window-order-persisted-2'],
+      ['about:blank#window-order-persisted-3'],
+    ])
+    const expectedWindowOrder = [
+      createdWindowIds[2],
+      createdWindowIds[1],
+      createdWindowIds[0],
+    ]
+    const timestamp = getTestLastUsedTimestamp()
+
+    await writeExtensionSettings(page, {
+      windowOrder: 'lastUsed',
+    })
+    await page.evaluate(
+      async (windowLastUsedAt) => {
+        await chrome.storage.local.set({ windowLastUsedAt })
+      },
+      {
+        [String(createdWindowIds[2])]: timestamp + 2,
+        [String(createdWindowIds[1])]: timestamp + 1,
+      },
+    )
+
+    await page.reload()
+    await page.waitForLoadState('domcontentloaded')
+    for (const windowId of createdWindowIds) {
+      await waitForTestId(page, `window-card-${windowId}`)
+    }
+    await waitForMainSurfaceToSettle(page)
+
+    await expect
+      .poll(() => getRenderedCreatedWindowOrder(page, createdWindowIds), {
+        timeout: 5000,
+      })
+      .toEqual(expectedWindowOrder)
+
+    const expectedSyncedWindowOrder = [
+      createdWindowIds[0],
+      createdWindowIds[1],
+      createdWindowIds[2],
+    ]
+    await page.evaluate(
+      async (windowLastUsedAt) => {
+        await chrome.storage.local.set({ windowLastUsedAt })
+      },
+      {
+        [String(createdWindowIds[0])]: timestamp + 6,
+        [String(createdWindowIds[1])]: timestamp + 5,
+        [String(createdWindowIds[2])]: timestamp + 4,
+      },
+    )
+
+    await page.locator('main').click()
+    await page.keyboard.press('s')
+    await waitForMainSurfaceToSettle(page)
+
+    await expect
+      .poll(() => getRenderedCreatedWindowOrder(page, createdWindowIds), {
+        timeout: 5000,
+      })
+      .toEqual(expectedSyncedWindowOrder)
+  })
+
   test('render last-used order for a tiny 3-window workspace', async () => {
     await setupLastUsedWindowOrderVisualScenario({
       windowCount: 3,


### PR DESCRIPTION
## Summary

- preserve the complete persisted last-used window sequence after refresh and keyboard sync
- keep the timestamped and fallback window order stable through filtering and auto-fit geometry changes
- add unit and integration regression coverage for reload, sync, filtering, and width-driven repacks

## Root Cause

The persisted timestamps survived reload, but reconstruction promoted only the newest timestamped window. Layout repacks also cleared the in-memory last-used column cache before rebuilding the default layout, so refresh, sync, and resize could discard the rest of the MRU sequence.

## Testing

- `pnpm build` (Chrome and Firefox production builds)
- commit hooks: Prettier and ESLint
- standalone comprehensive subagent review: no actionable findings
- unit, Playwright, and Linux visual/snapshot checks were not run per repository policy; Linux CI remains pending

## Release Notes

- Fix Last Used window order resetting after refresh or sync.